### PR TITLE
Add command to prune players who have left the server

### DIFF
--- a/guides/open.template.md
+++ b/guides/open.template.md
@@ -4,6 +4,9 @@ Players can drop themselves.
 If you need, you can also drop players.
 ```
 mc!forcedrop {}|@User```
+If players have left the server, you may have trouble mentioning them. You can drop all such players at once.
+```
+mc!prune {}```
 **Add bye**
 Players with a bye don't play in round 1.
 This gives them a free win.

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@ export { default as list } from "./list";
 export { default as open } from "./open";
 export { default as pie } from "./pie";
 export { default as players } from "./players";
+export { default as prune } from "./prune";
 export { default as removebye } from "./removebye";
 export { default as removechannel } from "./removechannel";
 export { default as removehost } from "./removehost";

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -1,0 +1,44 @@
+import { CommandDefinition } from "../Command";
+import { reply } from "../util/discord";
+import { getLogger } from "../util/logger";
+
+const logger = getLogger("command:prune");
+
+const command: CommandDefinition = {
+	name: "prune",
+	requiredArgs: ["id"],
+	executor: async (msg, args, support) => {
+		const [id] = args;
+		await support.tournamentManager.authenticateHost(id, msg.author.id);
+		logger.verbose(
+			JSON.stringify({
+				channel: msg.channel.id,
+				message: msg.id,
+				user: msg.author.id,
+				tournament: id,
+				command: "prune",
+				event: "attempt"
+			})
+		);
+		const players = await support.tournamentManager.prunePlayers(id);
+		logger.verbose(
+			JSON.stringify({
+				channel: msg.channel.id,
+				message: msg.id,
+				user: msg.author.id,
+				tournament: id,
+				command: "prune",
+				event: "success",
+				players
+			})
+		);
+		await reply(
+			msg,
+			`The following players have been dropped from Tournament ${id} because they are no longer in this server:\n<@${players.join(
+				">, <@"
+			)}>`
+		);
+	}
+};
+
+export default command;

--- a/src/discord/eris.ts
+++ b/src/discord/eris.ts
@@ -215,4 +215,13 @@ export class DiscordWrapperEris implements DiscordWrapper {
 			logger.error(e);
 		}
 	}
+
+	public async isUserInGuild(userID: string, guildId: string): Promise<boolean> {
+		const guild = this.bot.guilds.get(guildId);
+		if (!guild) {
+			// TODO: getRESTGuilds? return true as stopgap measure bc don't want to drop players carelessly
+			return true;
+		}
+		return !!guild.members.get(userID);
+	}
 }

--- a/src/discord/interface.ts
+++ b/src/discord/interface.ts
@@ -60,6 +60,7 @@ export interface DiscordWrapper {
 	getUsername(userId: string): string;
 	getRESTUsername(userId: string): Promise<string | null>;
 	sendDirectMessage(userId: string, content: DiscordMessageOut): Promise<void>;
+	isUserInGuild(userId: string, guildId: string): Promise<boolean>;
 }
 
 export class DiscordInterface {
@@ -139,6 +140,10 @@ export class DiscordInterface {
 
 	public async sendDirectMessage(userId: string, content: DiscordMessageOut): Promise<void> {
 		await this.api.sendDirectMessage(userId, content);
+	}
+
+	public async isUserInGuild(userId: string, guildId: string): Promise<boolean> {
+		return await this.api.isUserInGuild(userId, guildId);
 	}
 }
 

--- a/test/mocks/discord.ts
+++ b/test/mocks/discord.ts
@@ -118,4 +118,8 @@ export class DiscordWrapperMock implements DiscordWrapper {
 		}
 		this.messages[userId] = content;
 	}
+
+	public async isUserInGuild(): Promise<boolean> {
+		return true;
+	}
 }

--- a/test/mocks/tournament.ts
+++ b/test/mocks/tournament.ts
@@ -108,4 +108,8 @@ export class TournamentMock implements TournamentInterface {
 	public async removeBye(): Promise<string[]> {
 		return ["bye1"];
 	}
+
+	public async prunePlayers(): Promise<string[]> {
+		return [];
+	}
 }


### PR DESCRIPTION
## Description

This should serve as a stop-gap measure until #160 is complete and allow manual clean-up for any holes it may leave.

## Checklist

- [x] I am following the [contributing guidelines]( https://github.com/AlphaKretin/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
