### PR TITLE
drop, forcedrop: fix using an entity property after deletion

### DIFF
--- a/src/commands/forcedrop.ts
+++ b/src/commands/forcedrop.ts
@@ -75,6 +75,7 @@ const command: CommandDefinition = {
 				return;
 			}
 		}
+		// Properties of the entity will be undefined after it is deleted
 		const confirmed = !!participant.confirmed;
 		try {
 			await participant.remove();
@@ -97,7 +98,7 @@ const command: CommandDefinition = {
 				: `${name} was pending and dropped from **${tournament.name}**.`
 		);
 		log({ player: snowflake, event: "success" });
-		if (participant.tournament.status === TournamentStatus.PREPARING) {
+		if (tournament.status === TournamentStatus.PREPARING) {
 			const messages = await support.database.getRegisterMessages(id);
 			for (const m of messages) {
 				await removeReaction(msg.client, m.channelId, m.messageId, "✅", snowflake).catch(logger.info);


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

Fixes this exception
```
TypeError: Cannot read properties of undefined (reading 'status')
    at Object.executor (/src/commands/forcedrop.ts:100:30)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Command.run (/src/Command.ts:78:4)
    at Client.messageCreate (/src/events/messageCreate.ts:43:4)
```

I feel like my comment reads post facto like "people die when they are killed".

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
