### PR TITLE
Restore "get round" helper function

### DIFF
--- a/src/commands/tie.ts
+++ b/src/commands/tie.ts
@@ -1,5 +1,6 @@
 import { CommandDefinition } from "../Command";
 import { TournamentStatus } from "../database/interface";
+import { getRound } from "../util/challonge";
 import { getLogger } from "../util/logger";
 
 const logger = getLogger("command:tie");
@@ -27,7 +28,7 @@ const command: CommandDefinition = {
 		);
 		// gets only open matches
 		const matches = await support.challonge.getMatches(id, true);
-		const round = matches[0].round; // for reply
+		const round = getRound(id, matches); // for reply
 		for (const match of matches) {
 			// choice of player is arbitray, challonge correctly does not highlight a winner
 			await support.challonge.submitScore(id, match, match.player1, 0, 0);

--- a/src/round.ts
+++ b/src/round.ts
@@ -1,6 +1,7 @@
 import { Client, User, Util } from "discord.js";
 import { CommandSupport } from "./Command";
 import { DatabaseTournament, TournamentFormat } from "./database/interface";
+import { getRound } from "./util/challonge";
 import { dm, send } from "./util/discord";
 import { UserError } from "./util/errors";
 import { getLogger } from "./util/logger";
@@ -46,7 +47,7 @@ export async function advanceRoundDiscord(
 	await timeWizard.cancel(tournament.id);
 	logger.info(JSON.stringify({ tournament: tournament.id, minutes, skip }));
 	const matches = await challonge.getMatches(tournament.id, true);
-	const round = matches[0].round;
+	const round = getRound(tournament.id, matches);
 	const intro = `Round ${round} of ${tournament.name} has begun!`;
 	logger.info(JSON.stringify({ tournament: tournament.id, round }));
 	const role = await participantRole.get(tournament);

--- a/src/util/challonge.ts
+++ b/src/util/challonge.ts
@@ -23,7 +23,10 @@ export async function findClosedMatch(
 	// don't filter for player so we can get correct round no.
 	const matches = await challonge.getMatches(tournamentId, false);
 	// get round number from first open round
-	const round = matches.filter(m => m.open)[0].round;
+	const round = getRound(
+		tournamentId,
+		matches.filter(m => m.open)
+	);
 	const match = matches.find(m => m.round === round && (m.player1 === playerId || m.player2 === playerId));
 	if (!match) {
 		// may have the bye
@@ -32,4 +35,15 @@ export async function findClosedMatch(
 		);
 	}
 	return match;
+}
+
+export function getRound(tournamentId: string, cachedMatches: WebsiteMatch[]): number {
+	const matches = cachedMatches;
+	if (matches.length < 1) {
+		throw new UserError(
+			`No matches found for Tournament ${tournamentId}! This likely means the tournament either has not started or is finished!`
+		);
+	}
+	// All open matches should have the same round in Swiss. In Elim, we expect the array to be sorted by age and the lowest round should be the current.
+	return matches[0].round;
 }


### PR DESCRIPTION
## Description

Reintroduces necessary edge-case checking for when there are no matches from which to discern the round number

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
