### PR TITLE
Refer to tournament host for time procedures instead of modern synchronous TCG rules

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Move GitHub repository to the Dawnbrand Bots organization
 
 ### New Features
 - Switch to Discord.js from Eris so we can make use of recent Discord features (#325)
+- Refer to tournament host for time procedures instead of modern synchronous TCG rules (#358)
 
 ### Bug Fixes
 - Fix all file attachments breaking due to the switch to Discord.js, breaking two commands and part of registration (#327)

--- a/src/round.ts
+++ b/src/round.ts
@@ -117,7 +117,7 @@ export async function advanceRoundDiscord(
 			tournament.id,
 			tournament.publicChannels,
 			new Date(Date.now() + minutes * 60 * 1000),
-			`That's time in the round, <@&${role}>! Please end the current phase, then the player with the lower LP must forfeit!`,
+			`That's time in the round, <@&${role}>! Please follow appropriate time procedures as determined by your tournament hosts.`,
 			5 // update every 5 seconds
 		);
 	}


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

The message is only appropriate for synchronous tournaments hosted as if they were a YCS or locals. If played asynchronously, like the Reaper Format tournaments, this isn't necessarily appropriate. This also provides hosts flexibility in specifying time rules as this message isn't configurable.

Closes #355

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
