### PR TITLE
Standardize escaping Discord tags in messages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Move GitHub repository to the Dawnbrand Bots organization
 - Do not respond to `@everyone` and `@here`, another effect of the change to Discord.js (#330)
 - Fix register messages being deleted on bot startup (#332)
 - Fix race condition causing multiple round finish messages (#347)
+- Fix Discord tags sometimes formatting as markdown (#364)
 
 ## 2021-07-31 ([Chalislime Monthly July 2021](https://challonge.com/csmjuly2021))
 ### New Features

--- a/src/commands/addbye.ts
+++ b/src/commands/addbye.ts
@@ -1,3 +1,4 @@
+import { Util } from "discord.js";
 import { CommandDefinition } from "../Command";
 import { firstMentionOrFail } from "../util/discord";
 import { getLogger } from "../util/logger";
@@ -35,7 +36,8 @@ const command: CommandDefinition = {
 			})
 		);
 		const names = byes.map(snowflake => `<@${snowflake}>`).join(", ");
-		await msg.reply(`Bye registered for ${player} (${player.tag}) in **${tournament.name}**!\nAll byes: ${names}`);
+		const who = `${player} (${Util.escapeMarkdown(player.tag)})`;
+		await msg.reply(`Bye registered for ${who} in **${tournament.name}**!\nAll byes: ${names}`);
 	}
 };
 

--- a/src/commands/banlist.ts
+++ b/src/commands/banlist.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { MessageAttachment } from "discord.js";
+import { MessageAttachment, Util } from "discord.js";
 import fetch from "node-fetch";
 import { CommandDefinition } from "../Command";
 import { TournamentStatus } from "../database/interface";
@@ -54,8 +54,9 @@ const command: CommandDefinition = {
 			if (msg.attachments.size === 1 && attachment && attachment.name?.endsWith(".json")) {
 				// cap filesize for security at 0.5 MB
 				if (attachment.size > 512 * 1024) {
+					const who = `${Util.escapeMarkdown(msg.author.tag)} (${msg.author.id})`;
 					logger.notify(
-						`Potential abuse warning! ${msg.author.username}#${msg.author.discriminator} (${msg.author.id}) uploaded oversized card pool JSON "${attachment.name}" (${attachment.size}B).`
+						`Potential abuse warning! ${who} uploaded oversized card pool JSON "${attachment.name}" (${attachment.size}B).`
 					);
 					throw new UserError("JSON file too large! Please try again with a smaller file.");
 				}

--- a/src/commands/drop.ts
+++ b/src/commands/drop.ts
@@ -1,3 +1,4 @@
+import { Util } from "discord.js";
 import { CommandDefinition } from "../Command";
 import { TournamentStatus } from "../database/interface";
 import { Participant } from "../database/orm";
@@ -44,7 +45,7 @@ const command: CommandDefinition = {
 			await msg.reply(`**${tournament.name}** has already concluded!`);
 			return;
 		}
-		const who = `<@${msg.author.id}> (${msg.author.username}#${msg.author.discriminator})`;
+		const who = `${msg.author} (${Util.escapeMarkdown(msg.author.tag)})`;
 		if (participant.confirmed) {
 			if (
 				await dropPlayerChallonge(

--- a/src/commands/forcescore.ts
+++ b/src/commands/forcescore.ts
@@ -1,3 +1,4 @@
+import { Util } from "discord.js";
 import { CommandDefinition } from "../Command";
 import { TournamentStatus } from "../database/interface";
 import { findClosedMatch } from "../util/challonge";
@@ -62,9 +63,8 @@ const command: CommandDefinition = {
 				event: "success"
 			})
 		);
-		await msg.reply(
-			`Score of ${scores[0]}-${scores[1]} submitted in favour of ${player} (${player.tag}) in **${tournament.name}**!`
-		);
+		const who = `${player} (${Util.escapeMarkdown(player.tag)})`;
+		await msg.reply(`Score of ${scores[0]}-${scores[1]} submitted in favour of ${who} in **${tournament.name}**!`);
 	}
 };
 

--- a/src/commands/removebye.ts
+++ b/src/commands/removebye.ts
@@ -1,3 +1,4 @@
+import { Util } from "discord.js";
 import { CommandDefinition } from "../Command";
 import { firstMentionOrFail } from "../util/discord";
 import { getLogger } from "../util/logger";
@@ -36,7 +37,8 @@ const command: CommandDefinition = {
 			})
 		);
 		const names = byes.map(snowflake => `<@${snowflake}>`).join(", ");
-		await msg.reply(`Bye removed for ${player} (${player.tag}) in **${tournament.name}**!\nAll byes: ${names}`);
+		const who = `${player} (${Util.escapeMarkdown(player.tag)})`;
+		await msg.reply(`Bye removed for ${who} in **${tournament.name}**!\nAll byes: ${names}`);
 	}
 };
 

--- a/src/deck.ts
+++ b/src/deck.ts
@@ -1,4 +1,4 @@
-import { Message, MessageAttachment, MessageEmbed, ReplyMessageOptions } from "discord.js";
+import { Message, MessageAttachment, MessageEmbed, ReplyMessageOptions, Util } from "discord.js";
 import fetch from "node-fetch";
 import { CardIndex, CardVector, createAllowVector, Deck, DeckError, ICard } from "ydeck";
 import { Card, enums, YgoData } from "ygopro-data";
@@ -107,13 +107,11 @@ export class DeckManager {
 		// TODO: inconsistencies with banlist upload handling
 		const attachment = msg.attachments.first();
 		if (attachment && attachment.name?.endsWith(".ydk")) {
-			// cap filezie for security
+			// cap filesize for security
 			if (attachment.size > MAX_BYTES) {
-				// report potential abuse internally
 				// TODO: Would be useful to report tournament and server, but we don't have that data in this scope
-				logger.notify(
-					`Potential abuse warning! User ${msg.author.id} (@${msg.author.username}#${msg.author.discriminator}) submitted oversized deck file of ${attachment.size}B.`
-				);
+				const who = `${Util.escapeMarkdown(msg.author.tag)} (${msg.author.id})`;
+				logger.notify(`Potential abuse warning! ${who} submitted oversized deck file of ${attachment.size}B.`);
 				throw new UserError("YDK file too large! Please try again with a smaller file.");
 			}
 			const ydk = await this.extractYdk(attachment); // throws on network error

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -1,4 +1,4 @@
-import { GuildMember, PartialGuildMember } from "discord.js";
+import { GuildMember, PartialGuildMember, Util } from "discord.js";
 import { getConnection } from "typeorm";
 import { CommandSupport } from "../Command";
 import { Participant } from "../database/orm";
@@ -45,7 +45,8 @@ export function makeHandler({ database, challonge }: CommandSupport) {
 						challongeId: confirmed?.challongeId
 					}))
 				});
-				const who = `<@${member.id}> (${member.user?.tag})`;
+				// eslint-disable-next-line prefer-template
+				const who = `<@${member.id}> (` + Util.escapeMarkdown(`${member.user?.tag}`) + ")";
 				for (const participant of dropped) {
 					// For each tournament, inform the private channel that the user left and was dropped.
 					for (const channel of participant.tournament.privateChannels) {

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -111,7 +111,6 @@ export function registerEvents(bot: Client, prefix: string, support: CommandSupp
 					})
 				);
 			};
-			// TODO: username + discriminator should be known here
 			if (participant.confirmed) {
 				if (
 					await dropPlayerChallonge(

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,4 +1,4 @@
-import { Client, Message } from "discord.js";
+import { Client, Message, Util } from "discord.js";
 import { CardVector } from "ydeck";
 import { Command, CommandDefinition, CommandSupport } from "../Command";
 import { helpMessage } from "../config";
@@ -58,7 +58,7 @@ export function makeHandler(
 function log(level: keyof typeof logger, msg: Message, payload: Record<string, unknown>): void {
 	return logger[level](
 		JSON.stringify({
-			handle: `${msg.author.username}#${msg.author.discriminator}`,
+			handle: msg.author.tag,
 			user: msg.author.id,
 			message: msg.id,
 			...payload
@@ -171,9 +171,9 @@ async function verifyDeckAndConfirmPending(
 	bot: Client
 ): Promise<void> {
 	const { deck, formattedDeckMessage } = await verifyDeck(msg, decks, tournament.allowVector);
-	const username = `${msg.author.username}#${msg.author.discriminator}`;
+	const who = `${msg.author} (${Util.escapeMarkdown(msg.author.tag)})`;
 	try {
-		const challongeId = await challonge.registerPlayer(tournament.id, username, msg.author.id);
+		const challongeId = await challonge.registerPlayer(tournament.id, msg.author.tag, msg.author.id);
 		log("verbose", msg, { event: "challonge", tournament: tournament.id });
 		await database.confirmPlayer(tournament.id, msg.author.id, challongeId, deck.url);
 		log("verbose", msg, { event: "database", tournament: tournament.id });
@@ -183,7 +183,7 @@ async function verifyDeckAndConfirmPending(
 			await send(
 				bot,
 				channelId,
-				`Something went really wrong while trying to register <@${msg.author.id}> (${username}) for **${tournament.name}**!`
+				`Something went really wrong while trying to register ${who} for **${tournament.name}**!`
 			).catch(logger.error);
 		}
 		await msg
@@ -204,7 +204,7 @@ async function verifyDeckAndConfirmPending(
 			await send(
 				bot,
 				channel,
-				`<@${msg.author.id}> (${username}) has signed up for **${tournament.name}** with the following deck!${roleGrantWarning}`
+				`${who} has signed up for **${tournament.name}** with the following deck!${roleGrantWarning}`
 			);
 			await send(bot, channel, formattedDeckMessage);
 		} catch (error) {
@@ -231,7 +231,7 @@ async function verifyDeckAndUpdateConfirmed(
 	bot: Client
 ): Promise<void> {
 	const { deck, formattedDeckMessage } = await verifyDeck(msg, decks, tournament.allowVector);
-	const username = `${msg.author.username}#${msg.author.discriminator}`;
+	const who = `${msg.author} (${Util.escapeMarkdown(msg.author.tag)})`;
 	try {
 		await database.updateDeck(tournament.id, msg.author.id, deck.url);
 		log("verbose", msg, { event: "database", tournament: tournament.id });
@@ -241,7 +241,7 @@ async function verifyDeckAndUpdateConfirmed(
 			await send(
 				bot,
 				channel,
-				`Something went really wrong while trying to update deck of <@${msg.author.id}> (${username}) for **${tournament.name}**!`
+				`Something went really wrong while trying to update deck of ${who} for **${tournament.name}**!`
 			).catch(logger.error);
 		}
 		await msg
@@ -251,11 +251,7 @@ async function verifyDeckAndUpdateConfirmed(
 	}
 	for (const channel of tournament.privateChannels) {
 		try {
-			await send(
-				bot,
-				channel,
-				`<@${msg.author.id}> (${username}) has updated their deck for **${tournament.name}** to the following!`
-			);
+			await send(bot, channel, `${who} has updated their deck for **${tournament.name}** to the following!`);
 			await send(bot, channel, formattedDeckMessage);
 		} catch (error) {
 			logger.error(error);


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

Discord tags were inconsistently escaped across the codebase. This should harmonize everything. Search the codebase for `.discriminator` and `.tag`! I'm not sure if creating a function for `${user} (${Util.escapeMarkdown(user.tag)})` would obscure things.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
