### PR TITLE
Support SQLite databases, gated by SQLITE_DB envvar

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,11 +2,11 @@ import dotenv from "dotenv";
 dotenv.config();
 
 function assertEnv(envvar: string): string {
-	if (process.env[envvar] === undefined) {
+	const value = process.env[envvar];
+	if (value === undefined) {
 		throw new Error(`Missing environment variable ${envvar}`);
 	}
-	// For some reason with indexed access, the cast is needed despite the if check
-	return process.env[envvar] as string;
+	return value;
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type

--- a/src/database/orm/ChallongeTournament.ts
+++ b/src/database/orm/ChallongeTournament.ts
@@ -3,6 +3,7 @@ import { CardVector } from "ydeck";
 import { TournamentFormat, TournamentStatus } from "../interface";
 import { ConfirmedParticipant } from "./ConfirmedParticipant";
 import { Countdown } from "./Countdown";
+import { EnumColumn, JsonArrayColumn } from "./decorators";
 import { Participant } from "./Participant";
 import { RegisterMessage } from "./RegisterMessage";
 
@@ -28,28 +29,24 @@ export class ChallongeTournament extends BaseEntity {
 	owningDiscordServer!: string;
 
 	/// Formats supported by Challonge, named the same way.
-	@Column({ type: "enum", enum: TournamentFormat, default: TournamentFormat.SWISS })
+	@EnumColumn(TournamentFormat, "SWISS")
 	format!: TournamentFormat;
 
 	/// An array of Discord user snowflakes. Whenever hosts are queried, the rest
 	/// of the tournament information is wanted anyway. Should be distinct.
-	// @Column("varchar", { length: 20, array: true, default: "{}" })
-	// https://github.com/typeorm/typeorm/issues/6990
-	@Column("json", { default: [] })
+	@JsonArrayColumn()
 	hosts!: string[];
 
 	/// An array of Discord channel snowflakes. Should be distinct.
-	// @Column("varchar", { length: 20, array: true, default: "{}" })
-	@Column("json", { default: [] })
+	@JsonArrayColumn()
 	publicChannels!: string[];
 
 	/// An array of Discord channel snowflakes. Should be distinct.
-	// @Column("varchar", { length: 20, array: true, default: "{}" })
-	@Column("json", { default: [] })
+	@JsonArrayColumn()
 	privateChannels!: string[];
 
 	/// Simple state progression in the listed order above.
-	@Column({ type: "enum", enum: TournamentStatus, default: TournamentStatus.PREPARING })
+	@EnumColumn(TournamentStatus, "PREPARING")
 	status!: TournamentStatus;
 
 	/// Optional maximum capacity of this tournament. 0 indicates no limit. Negatives invalid.

--- a/src/database/orm/Countdown.ts
+++ b/src/database/orm/Countdown.ts
@@ -12,7 +12,7 @@ export class Countdown extends BaseEntity {
 	id!: number;
 
 	/// Store the end time as a UTC timestamp in Postgres, avoid shenanigans.
-	@Column("timestamptz")
+	@Column(process.env.SQLITE_DB ? "datetime" : "timestamptz")
 	end!: Date;
 
 	/// Discord channel snowflake. A uint64 is at most 20 digits in decimal.

--- a/src/database/orm/ManualTournament.ts
+++ b/src/database/orm/ManualTournament.ts
@@ -1,5 +1,6 @@
 import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 import { TournamentStatus } from "../interface";
+import { EnumColumn, JsonArrayColumn } from "./decorators";
 import { ManualDeckSubmission } from "./ManualDeckSubmission";
 import { ManualParticipant } from "./ManualParticipant";
 
@@ -25,9 +26,7 @@ export class ManualTournament extends BaseEntity {
 
 	/// An array of Discord user snowflakes. Whenever hosts are queried, the rest
 	/// of the tournament information is wanted anyway. Should be distinct.
-	// @Column("varchar", { length: 20, array: true, default: "{}" })
-	// https://github.com/typeorm/typeorm/issues/6990
-	@Column("json", { default: [] })
+	@JsonArrayColumn()
 	hosts!: string[];
 
 	/// Discord channel snowflake. A uint64 is at most 20 digits in decimal.
@@ -39,7 +38,7 @@ export class ManualTournament extends BaseEntity {
 	privateChannel?: string;
 
 	/// Simple state progression in the listed order above.
-	@Column({ type: "enum", enum: TournamentStatus, default: TournamentStatus.PREPARING })
+	@EnumColumn(TournamentStatus, "PREPARING")
 	status!: TournamentStatus;
 
 	/// Optional maximum capacity of this tournament. 0 indicates no limit. Negatives invalid.

--- a/src/database/orm/decorators.ts
+++ b/src/database/orm/decorators.ts
@@ -6,8 +6,9 @@ export function JsonArrayColumn(): PropertyDecorator {
 		? Column("text", {
 				default: "[]",
 				transformer: {
-					from: (raw: string | null) => (raw ? JSON.parse(raw) : []),
-					to: (entity?: string[]) => (entity ? JSON.stringify(entity) : "[]")
+					// Workaround for https://github.com/typeorm/typeorm/issues/5719 (transformer called twice)
+					from: (raw: string) => (Array.isArray(raw) ? raw : JSON.parse(raw)),
+					to: (entity?: string[]) => entity && JSON.stringify(entity)
 				}
 		  })
 		: // @Column("varchar", { length: 20, array: true, default: "{}" })

--- a/src/database/orm/decorators.ts
+++ b/src/database/orm/decorators.ts
@@ -1,0 +1,22 @@
+import { EnumLike } from "discord.js";
+import { Column } from "typeorm";
+
+export function JsonArrayColumn(): PropertyDecorator {
+	return process.env.SQLITE_DB
+		? Column("text", {
+				default: "[]",
+				transformer: {
+					from: (raw: string | null) => (raw ? JSON.parse(raw) : []),
+					to: (entity?: string[]) => (entity ? JSON.stringify(entity) : "[]")
+				}
+		  })
+		: // @Column("varchar", { length: 20, array: true, default: "{}" })
+		  // https://github.com/typeorm/typeorm/issues/6990
+		  Column("json", { default: [] });
+}
+
+export function EnumColumn<E, V>(clazz: EnumLike<E, V>, defaultKey: keyof E): PropertyDecorator {
+	return process.env.SQLITE_DB
+		? Column("text", { default: clazz[defaultKey] })
+		: Column({ type: "enum", enum: clazz, default: clazz[defaultKey] });
+}

--- a/src/database/orm/index.ts
+++ b/src/database/orm/index.ts
@@ -13,24 +13,45 @@ import { RegisterMessage } from "./RegisterMessage";
 const logger = getLogger("typeorm");
 
 export async function initializeConnection(postgresqlUrl: string): Promise<void> {
-	await createConnection({
-		type: "postgres",
-		url: postgresqlUrl,
-		entities: [
-			ChallongeTournament,
-			ConfirmedParticipant,
-			Countdown,
-			Participant,
-			RegisterMessage,
-			ManualTournament,
-			ManualParticipant,
-			ManualDeckSubmission
-		],
-		logging: "all",
-		logger: "debug",
-		synchronize: true // TODO: process.env.NODE_ENV === "development" and investigate migrations
-	});
-	logger.info(`Connected to PostgreSQL via TypeORM`);
+	if (process.env.SQLITE_DB) {
+		await createConnection({
+			type: "better-sqlite3",
+			database: process.env.SQLITE_DB,
+			entities: [
+				ChallongeTournament,
+				ConfirmedParticipant,
+				Countdown,
+				Participant,
+				RegisterMessage,
+				ManualTournament,
+				ManualParticipant,
+				ManualDeckSubmission
+			],
+			logging: "all",
+			logger: "debug",
+			synchronize: true
+		});
+		logger.info(`Connected to SQLite via TypeORM`);
+	} else {
+		await createConnection({
+			type: "postgres",
+			url: postgresqlUrl,
+			entities: [
+				ChallongeTournament,
+				ConfirmedParticipant,
+				Countdown,
+				Participant,
+				RegisterMessage,
+				ManualTournament,
+				ManualParticipant,
+				ManualDeckSubmission
+			],
+			logging: "all",
+			logger: "debug",
+			synchronize: true // TODO: process.env.NODE_ENV === "development" and investigate migrations
+		});
+		logger.info(`Connected to PostgreSQL via TypeORM`);
+	}
 }
 
 export {


### PR DESCRIPTION
To use, set SQLITE_DB=:memory: or SQLITE_DB=some_filename.db3

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [x] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [x] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [x] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
