### PR TITLE
Deck submission approval process by encoding tournamentId in message component customId

### DIFF
--- a/src/SlashCommand.ts
+++ b/src/SlashCommand.ts
@@ -65,10 +65,10 @@ export abstract class AutocompletableCommand extends SlashCommand {
 
 export interface ButtonClickHandler {
 	readonly buttonIds: string[];
-	click(interaction: ButtonInteraction): Promise<void>;
+	click(interaction: ButtonInteraction, ...args: string[]): Promise<void>;
 }
 
 export interface MessageModalSubmitHandler {
 	readonly modalIds: string[];
-	submit(interaction: ModalMessageModalSubmitInteraction): Promise<void>;
+	submit(interaction: ModalMessageModalSubmitInteraction, ...args: string[]): Promise<void>;
 }

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -18,7 +18,13 @@ import { UpdateCommand } from "../slash/update";
 import { AutocompletableCommand, ButtonClickHandler, MessageModalSubmitHandler, SlashCommand } from "../SlashCommand";
 import { serialiseInteraction } from "../util";
 import { getLogger } from "../util/logger";
-import { decodeCustomId } from "../slash/database";
+import {
+	AcceptButtonHandler,
+	AcceptLabelModal,
+	decodeCustomId,
+	RejectButtonHandler,
+	RejectReasonModal
+} from "../slash/database";
 
 const logger = getLogger("interaction");
 
@@ -41,8 +47,8 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 		new StartCommand(),
 		new ListCommand(organiserRole)
 	];
-	const buttonArray = [new RegisterButtonHandler()];
-	const messageModalArray = [new FriendCodeModalHandler()];
+	const buttonArray = [new RegisterButtonHandler(), new AcceptButtonHandler(), new RejectButtonHandler()];
+	const messageModalArray = [new FriendCodeModalHandler(), new AcceptLabelModal(), new RejectReasonModal()];
 	const contextArray = [new ForceDropContextCommand()];
 
 	const commands = new Map<string, SlashCommand>();

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -90,8 +90,8 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					buttonId: interaction.customId
 				})
 			);
-			const name = decodeCustomId(interaction.customId)[0];
-			await buttons.get(name)?.click(interaction);
+			const [name, args] = decodeCustomId(interaction.customId)[0];
+			await buttons.get(name)?.click(interaction, ...args);
 		} else if (interaction.isModalSubmit() && interaction.isFromMessage()) {
 			logger.verbose(
 				JSON.stringify({
@@ -103,8 +103,8 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					modalId: interaction.customId
 				})
 			);
-			const name = decodeCustomId(interaction.customId)[0];
-			await messageModals.get(name)?.submit(interaction);
+			const [name, args] = decodeCustomId(interaction.customId)[0];
+			await messageModals.get(name)?.submit(interaction, ...args);
 		} else if (interaction.isContextMenuCommand()) {
 			logger.verbose(serialiseInteraction(interaction));
 			await contexts.get(interaction.commandName)?.run(interaction);

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -90,7 +90,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					buttonId: interaction.customId
 				})
 			);
-			const [name, args] = decodeCustomId(interaction.customId)[0];
+			const [name, args] = decodeCustomId(interaction.customId);
 			await buttons.get(name)?.click(interaction, ...args);
 		} else if (interaction.isModalSubmit() && interaction.isFromMessage()) {
 			logger.verbose(
@@ -103,7 +103,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					modalId: interaction.customId
 				})
 			);
-			const [name, args] = decodeCustomId(interaction.customId)[0];
+			const [name, args] = decodeCustomId(interaction.customId);
 			await messageModals.get(name)?.submit(interaction, ...args);
 		} else if (interaction.isContextMenuCommand()) {
 			logger.verbose(serialiseInteraction(interaction));

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -18,6 +18,7 @@ import { UpdateCommand } from "../slash/update";
 import { AutocompletableCommand, ButtonClickHandler, MessageModalSubmitHandler, SlashCommand } from "../SlashCommand";
 import { serialiseInteraction } from "../util";
 import { getLogger } from "../util/logger";
+import { decodeCustomId } from "../slash/database";
 
 const logger = getLogger("interaction");
 
@@ -89,7 +90,8 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					buttonId: interaction.customId
 				})
 			);
-			await buttons.get(interaction.customId)?.click(interaction);
+			const name = decodeCustomId(interaction.customId)[0];
+			await buttons.get(name)?.click(interaction);
 		} else if (interaction.isModalSubmit() && interaction.isFromMessage()) {
 			logger.verbose(
 				JSON.stringify({
@@ -101,7 +103,8 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					modalId: interaction.customId
 				})
 			);
-			await messageModals.get(interaction.customId)?.submit(interaction);
+			const name = decodeCustomId(interaction.customId)[0];
+			await messageModals.get(name)?.submit(interaction);
 		} else if (interaction.isContextMenuCommand()) {
 			logger.verbose(serialiseInteraction(interaction));
 			await contexts.get(interaction.commandName)?.run(interaction);

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -4,7 +4,7 @@ import { ContextCommand } from "../ContextCommand";
 import { ChannelCommand } from "../slash/channel";
 import { CreateCommand } from "../slash/create";
 import { CsvCommand } from "../slash/csv";
-import { DeckCommand } from "../slash/deck";
+import { AcceptButtonHandler, AcceptLabelModal, DeckCommand, RejectReasonModal } from "../slash/deck";
 import { DropCommand } from "../slash/drop";
 import { FinishCommand } from "../slash/finish";
 import { ForceDropContextCommand, ForceDropSlashCommand } from "../slash/forcedrop";
@@ -18,13 +18,6 @@ import { UpdateCommand } from "../slash/update";
 import { AutocompletableCommand, ButtonClickHandler, MessageModalSubmitHandler, SlashCommand } from "../SlashCommand";
 import { serialiseInteraction } from "../util";
 import { getLogger } from "../util/logger";
-import {
-	AcceptButtonHandler,
-	AcceptLabelModal,
-	decodeCustomId,
-	RejectButtonHandler,
-	RejectReasonModal
-} from "../slash/database";
 
 const logger = getLogger("interaction");
 
@@ -47,7 +40,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 		new StartCommand(),
 		new ListCommand(organiserRole)
 	];
-	const buttonArray = [new RegisterButtonHandler(), new AcceptButtonHandler(), new RejectButtonHandler()];
+	const buttonArray = [new RegisterButtonHandler(), new AcceptButtonHandler(), new RegisterButtonHandler()];
 	const messageModalArray = [new FriendCodeModalHandler(), new AcceptLabelModal(), new RejectReasonModal()];
 	const contextArray = [new ForceDropContextCommand()];
 
@@ -116,4 +109,14 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 			await contexts.get(interaction.commandName)?.run(interaction);
 		}
 	};
+}
+
+export function encodeCustomId(idName: string, ...args: Array<string | number>): string {
+	args.unshift(idName);
+	return args.join("#");
+}
+
+export function decodeCustomId(id: string): [string, string[]] {
+	const [name, ...args] = id.split("#");
+	return [name, args];
 }

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -96,7 +96,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					buttonId: interaction.customId
 				})
 			);
-			const [name, ...args] = decodeCustomId(interaction.customId);
+			const [name, args] = decodeCustomId(interaction.customId);
 			await buttons.get(name)?.click(interaction, ...args);
 		} else if (interaction.isModalSubmit() && interaction.isFromMessage()) {
 			logger.verbose(
@@ -109,7 +109,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					modalId: interaction.customId
 				})
 			);
-			const [name, ...args] = decodeCustomId(interaction.customId);
+			const [name, args] = decodeCustomId(interaction.customId);
 			await messageModals.get(name)?.submit(interaction, ...args);
 		} else if (interaction.isContextMenuCommand()) {
 			logger.verbose(serialiseInteraction(interaction));

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -96,7 +96,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					buttonId: interaction.customId
 				})
 			);
-			const [name, args] = decodeCustomId(interaction.customId);
+			const [name, ...args] = decodeCustomId(interaction.customId);
 			await buttons.get(name)?.click(interaction, ...args);
 		} else if (interaction.isModalSubmit() && interaction.isFromMessage()) {
 			logger.verbose(
@@ -109,7 +109,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 					modalId: interaction.customId
 				})
 			);
-			const [name, args] = decodeCustomId(interaction.customId);
+			const [name, ...args] = decodeCustomId(interaction.customId);
 			await messageModals.get(name)?.submit(interaction, ...args);
 		} else if (interaction.isContextMenuCommand()) {
 			logger.verbose(serialiseInteraction(interaction));

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -4,7 +4,13 @@ import { ContextCommand } from "../ContextCommand";
 import { ChannelCommand } from "../slash/channel";
 import { CreateCommand } from "../slash/create";
 import { CsvCommand } from "../slash/csv";
-import { AcceptButtonHandler, AcceptLabelModal, DeckCommand, RejectReasonModal } from "../slash/deck";
+import {
+	AcceptButtonHandler,
+	AcceptLabelModal,
+	DeckCommand,
+	RejectButtonHandler,
+	RejectReasonModal
+} from "../slash/deck";
 import { DropCommand } from "../slash/drop";
 import { FinishCommand } from "../slash/finish";
 import { ForceDropContextCommand, ForceDropSlashCommand } from "../slash/forcedrop";
@@ -40,7 +46,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 		new StartCommand(),
 		new ListCommand(organiserRole)
 	];
-	const buttonArray = [new RegisterButtonHandler(), new AcceptButtonHandler(), new RegisterButtonHandler()];
+	const buttonArray = [new RegisterButtonHandler(), new AcceptButtonHandler(), new RejectButtonHandler()];
 	const messageModalArray = [new FriendCodeModalHandler(), new AcceptLabelModal(), new RejectReasonModal()];
 	const contextArray = [new ForceDropContextCommand()];
 

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -170,7 +170,7 @@ export async function onDirectMessage(
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
 		outMessage += `\n${deck.content}`;
 
-		const row = generateDeckValidateButtons();
+		const row = generateDeckValidateButtons(deck.tournament);
 		if (deck.participant.tournament.privateChannel) {
 			await send(msg.client, deck.participant.tournament.privateChannel, {
 				content: outMessage,
@@ -194,6 +194,8 @@ export async function onDirectMessage(
 			await msg.reply("You need to upload screenshots of your deck. Please try again.");
 			return;
 		}
+		// a submitted player should definitely have a deck
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const d = submitted[0].deck!;
 		d.approved = false;
 		d.content = images.map(i => i.url).join("\n");
@@ -202,7 +204,7 @@ export async function onDirectMessage(
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
 		outMessage += `\n${d.content}`;
 
-		const row = generateDeckValidateButtons();
+		const row = generateDeckValidateButtons(d.tournament);
 		if (submitted[0].tournament.privateChannel) {
 			await send(msg.client, submitted[0].tournament.privateChannel, {
 				content: outMessage,

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -204,7 +204,7 @@ export async function onDirectMessage(
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
 		outMessage += `\n${d.content}`;
 
-		const row = generateDeckValidateButtons(d.tournament);
+		const row = generateDeckValidateButtons(submitted[0].tournament);
 		if (submitted[0].tournament.privateChannel) {
 			await send(msg.client, submitted[0].tournament.privateChannel, {
 				content: outMessage,

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -7,7 +7,7 @@ import { ManualDeckSubmission, ManualParticipant } from "../database/orm";
 import { DatabaseWrapperPostgres } from "../database/postgres";
 import { DeckManager } from "../deck";
 import { ParticipantRoleProvider } from "../role/participant";
-import { generateDeckValidateButtons } from "../slash/database";
+import { generateDeckValidateButtons } from "../slash/deck";
 import { send } from "../util/discord";
 import { getLogger } from "../util/logger";
 import { Public } from "../util/types";

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -170,7 +170,7 @@ export async function onDirectMessage(
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
 		outMessage += `\n${deck.content}`;
 
-		const row = generateDeckValidateButtons(deck.tournament);
+		const row = generateDeckValidateButtons(registering[0].tournament);
 		if (deck.participant.tournament.privateChannel) {
 			await send(msg.client, deck.participant.tournament.privateChannel, {
 				content: outMessage,

--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -91,12 +91,9 @@ export function encodeCustomId(idName: string, ...args: Array<string | number>):
 	return args.join("#");
 }
 
-export function decodeCustomId(id: string): string[] {
-	const args = id.split("#");
-	// the result of spllit has at least 1 entry unless the string is empty
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const name = args.shift()!;
-	return [name, ...args];
+export function decodeCustomId(id: string): [string, string[]] {
+	const [name, ...args] = id.split("#");
+	return [name, args];
 }
 
 export function generateDeckValidateButtons(tournament: ManualTournament): ActionRowBuilder<ButtonBuilder> {

--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -157,7 +157,11 @@ export class AcceptLabelModal implements MessageModalSubmitHandler {
 	async submit(interaction: ModalMessageModalSubmitInteraction, ...args: string[]): Promise<void> {
 		const tournamentIdString = args[0];
 		const deck = await ManualDeckSubmission.findOneOrFail({
-			where: { discordId: interaction.user.id, tournamentId: parseInt(tournamentIdString, 10) }
+			where: {
+				discordId: interaction.user.id,
+				tournamentId: parseInt(tournamentIdString, 10)
+			},
+			relations: ["tournament"]
 		});
 		const tournament = deck.tournament;
 		const player = await interaction.client.users.fetch(deck.discordId);
@@ -188,7 +192,11 @@ export class RejectReasonModal implements MessageModalSubmitHandler {
 	async submit(interaction: ModalMessageModalSubmitInteraction, ...args: string[]): Promise<void> {
 		const tournamentIdString = args[0];
 		const deck = await ManualDeckSubmission.findOneOrFail({
-			where: { discordId: interaction.user.id, tournamentId: parseInt(tournamentIdString, 10) }
+			where: {
+				discordId: interaction.user.id,
+				tournamentId: parseInt(tournamentIdString, 10)
+			},
+			relations: ["tournament"]
 		});
 		const tournament = deck.tournament;
 		const player = await interaction.client.users.fetch(deck.discordId);

--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -218,13 +218,11 @@ export class RejectReasonModal implements MessageModalSubmitHandler {
 		}
 		await player.send(message);
 		// log success to TO
-		if (tournament.privateChannel) {
-			await send(
-				interaction.client,
-				tournament.privateChannel,
-				`${userMention}'s deck for ${tournament.name} has been rejected by ${userMention(interaction.user.id)}`
-			);
-		}
+		await interaction.reply(
+			`${userMention(player.id)}'s deck for ${tournament.name} has been rejected by ${userMention(
+				interaction.user.id
+			)}`
+		);
 	}
 }
 

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -9,13 +9,7 @@ import {
 import { ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
 import { getLogger, Logger } from "../util/logger";
-import {
-	authenticateHost,
-	autocompleteTournament,
-	awaitDeckValidationButtons,
-	generateDeckValidateButtons,
-	tournamentOption
-} from "./database";
+import { authenticateHost, autocompleteTournament, generateDeckValidateButtons, tournamentOption } from "./database";
 
 export class DeckCommand extends AutocompletableCommand {
 	#logger = getLogger("command:deck");
@@ -80,9 +74,7 @@ export class DeckCommand extends AutocompletableCommand {
 			return;
 		}
 
-		const row = generateDeckValidateButtons();
-		const response = await interaction.reply({ content: outMessage, fetchReply: true, components: [row] });
-		// errors handled by internal callbacks
-		awaitDeckValidationButtons(interaction, response, tournament, this.logger, playerDeck);
+		const row = generateDeckValidateButtons(tournament);
+		await interaction.reply({ content: outMessage, components: [row] });
 	}
 }

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -1,15 +1,22 @@
-import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
+import { ButtonStyle, RESTPostAPIApplicationCommandsJSONBody, TextInputStyle } from "discord-api-types/v10";
 import {
+	ActionRowBuilder,
 	AutocompleteInteraction,
+	ButtonBuilder,
+	ButtonInteraction,
 	CacheType,
 	ChatInputCommandInteraction,
+	ModalBuilder,
+	ModalMessageModalSubmitInteraction,
 	SlashCommandBuilder,
+	TextInputBuilder,
 	userMention
 } from "discord.js";
-import { ManualTournament } from "../database/orm";
-import { AutocompletableCommand } from "../SlashCommand";
+import { ManualDeckSubmission, ManualTournament } from "../database/orm";
+import { encodeCustomId } from "../events/interaction";
+import { AutocompletableCommand, ButtonClickHandler, MessageModalSubmitHandler } from "../SlashCommand";
 import { getLogger, Logger } from "../util/logger";
-import { authenticateHost, autocompleteTournament, generateDeckValidateButtons, tournamentOption } from "./database";
+import { authenticateHost, autocompleteTournament, tournamentOption } from "./database";
 
 export class DeckCommand extends AutocompletableCommand {
 	#logger = getLogger("command:deck");
@@ -76,5 +83,132 @@ export class DeckCommand extends AutocompletableCommand {
 
 		const row = generateDeckValidateButtons(tournament);
 		await interaction.reply({ content: outMessage, components: [row] });
+	}
+}
+
+export function generateDeckValidateButtons(tournament: ManualTournament): ActionRowBuilder<ButtonBuilder> {
+	const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+		new ButtonBuilder()
+			.setCustomId(encodeCustomId("accept", tournament.tournamentId))
+			.setLabel("Accept")
+			.setStyle(ButtonStyle.Success),
+		new ButtonBuilder()
+			.setCustomId(encodeCustomId("reject", tournament.tournamentId))
+			.setLabel("Reject")
+			.setStyle(ButtonStyle.Danger)
+	);
+	return row;
+}
+
+export class AcceptButtonHandler implements ButtonClickHandler {
+	readonly buttonIds = ["accept"];
+
+	async click(interaction: ButtonInteraction, ...args: string[]): Promise<void> {
+		const tournamentIdString = args[0];
+		const modal = new ModalBuilder()
+			.setCustomId(encodeCustomId("acceptModal", tournamentIdString))
+			.setTitle("Accept Deck");
+		const deckLabelInput = new TextInputBuilder()
+			.setCustomId("acceptDeckLabel")
+			.setLabel("What is the deck's theme?")
+			.setStyle(TextInputStyle.Short)
+			.setRequired(false);
+		const actionRow = new ActionRowBuilder<TextInputBuilder>().addComponents(deckLabelInput);
+		modal.addComponents(actionRow);
+		await interaction.showModal(modal);
+	}
+}
+
+export class RejectButtonHandler implements ButtonClickHandler {
+	readonly buttonIds = ["reject"];
+
+	async click(interaction: ButtonInteraction, ...args: string[]): Promise<void> {
+		const tournamentIdString = args[0];
+		const modal = new ModalBuilder()
+			.setCustomId(encodeCustomId("rejectModal", tournamentIdString))
+			.setTitle("Reject Deck");
+		const rejectReasonInput = new TextInputBuilder()
+			.setCustomId("rejectReason")
+			.setLabel("Why is the deck illegal?")
+			.setStyle(TextInputStyle.Paragraph)
+			.setRequired(false);
+		const actionRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rejectReasonInput);
+		modal.addComponents(actionRow);
+		await interaction.showModal(modal);
+	}
+}
+
+export class AcceptLabelModal implements MessageModalSubmitHandler {
+	readonly modalIds = ["acceptModal"];
+
+	async submit(interaction: ModalMessageModalSubmitInteraction, ...args: string[]): Promise<void> {
+		const tournamentIdString = args[0];
+		const tournamentId = parseInt(tournamentIdString, 10);
+		const deck = await ManualDeckSubmission.findOneOrFail({
+			where: {
+				discordId: interaction.user.id,
+				tournamentId: tournamentId
+			},
+			relations: ["tournament"]
+		});
+		const tournament = deck.tournament;
+		const player = await interaction.client.users.fetch(deck.discordId);
+
+		let label: string | undefined = interaction.fields.getTextInputValue("acceptDeckLabel");
+		if (label.length === 0) {
+			label = undefined;
+		}
+
+		// set deck as approved and add label
+		// manual query to workaround bug
+		await ManualDeckSubmission.createQueryBuilder()
+			.update()
+			.set({ approved: true, label })
+			.where("tournamentId = :tournamentId AND discordId = :discordId", {
+				tournamentId,
+				discordId: interaction.user.id
+			})
+			.execute();
+		// provide feedback to player
+		await player.send(`Your deck has been accepted by the hosts! You are now registered for ${tournament.name}.`);
+		// TODO: Give player participant role
+		// log success to TO
+		await interaction.reply(
+			`${userMention(player.id)}'s deck for ${tournament.name} has been approved by ${userMention(
+				interaction.user.id
+			)}`
+		);
+	}
+}
+
+export class RejectReasonModal implements MessageModalSubmitHandler {
+	readonly modalIds = ["rejectModal"];
+
+	async submit(interaction: ModalMessageModalSubmitInteraction, ...args: string[]): Promise<void> {
+		const tournamentIdString = args[0];
+		const deck = await ManualDeckSubmission.findOneOrFail({
+			where: {
+				discordId: interaction.user.id,
+				tournamentId: parseInt(tournamentIdString, 10)
+			},
+			relations: ["tournament"]
+		});
+		const tournament = deck.tournament;
+		const player = await interaction.client.users.fetch(deck.discordId);
+		// clear deck submission
+		await deck.remove(); // do we need to update the link on the player's end?
+		// provide feedback to player
+		let message = `Your deck has been rejected by the hosts. Please update your deck and try again.`;
+		const reason = interaction.fields.getTextInputValue("rejectReason");
+		if (reason.length > 0) {
+			message += `\nReason: ${reason}`;
+		}
+		await player.send(message);
+		// log success to TO
+		await interaction.reply(
+			`${userMention(player.id)}'s deck for ${tournament.name} has been rejected by ${userMention(
+				interaction.user.id
+			)}`
+		);
 	}
 }


### PR DESCRIPTION
## Description

Implements a system to pass additional information to otherwise-isolated interaction handlers through the customId, allowing the deck validation system to be updated and use them. 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
