### PR TITLE
Add command to list decks awaiting approval

### DIFF
--- a/src/cli/register-slash.ts
+++ b/src/cli/register-slash.ts
@@ -16,6 +16,7 @@ import { OpenCommand } from "../slash/open";
 import { CsvCommand } from "../slash/csv";
 import { StartCommand } from "../slash/start";
 import { ListCommand } from "../slash/list";
+import { QueueCommand } from "../slash/queue";
 
 export const classes = [
 	// Register here and in events/interaction.ts
@@ -25,7 +26,7 @@ export const classes = [
 	ChannelCommand,
 	UpdateCommand,
 	InfoCommand,
-  ForceDropSlashCommand,
+	ForceDropSlashCommand,
 	ForceDropContextCommand,
 	DropCommand,
 	DeckCommand,
@@ -33,7 +34,8 @@ export const classes = [
 	OpenCommand,
 	CsvCommand,
 	StartCommand,
-  ListCommand
+	ListCommand,
+	QueueCommand
 ];
 
 // Register Slash Commands on CI

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -25,6 +25,7 @@ import { UpdateCommand } from "../slash/update";
 import { AutocompletableCommand, ButtonClickHandler, MessageModalSubmitHandler, SlashCommand } from "../SlashCommand";
 import { serialiseInteraction } from "../util";
 import { getLogger } from "../util/logger";
+import { QueueCommand } from "../slash/queue";
 
 const logger = getLogger("interaction");
 
@@ -45,7 +46,8 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 		new OpenCommand(),
 		new CsvCommand(),
 		new StartCommand(),
-		new ListCommand(organiserRole)
+		new ListCommand(organiserRole),
+		new QueueCommand()
 	];
 	const buttonArray = [
 		new RegisterButtonHandler(),

--- a/src/slash/queue.ts
+++ b/src/slash/queue.ts
@@ -63,6 +63,8 @@ export class QueueCommand extends AutocompletableCommand {
 		}
 		const players = decks.map(d => userMention(d.discordId));
 
-		await interaction.reply(`${players.length} players are waiting for deck approval. List\n${players.join(", ")}`);
+		await interaction.reply(
+			`${players.length} player(s) are waiting for deck approval. List:\n${players.join(", ")}`
+		);
 	}
 }

--- a/src/slash/queue.ts
+++ b/src/slash/queue.ts
@@ -1,0 +1,68 @@
+import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
+import {
+	AutocompleteInteraction,
+	CacheType,
+	ChatInputCommandInteraction,
+	SlashCommandBuilder,
+	userMention
+} from "discord.js";
+import { ManualDeckSubmission, ManualTournament } from "../database/orm";
+import { AutocompletableCommand } from "../SlashCommand";
+import { getLogger, Logger } from "../util/logger";
+import { authenticateHost, autocompleteTournament, tournamentOption } from "./database";
+
+export class QueueCommand extends AutocompletableCommand {
+	#logger = getLogger("command:queue");
+
+	constructor() {
+		super();
+	}
+
+	static override get meta(): RESTPostAPIApplicationCommandsJSONBody {
+		return new SlashCommandBuilder()
+			.setName("queue")
+			.setDescription("List players with submitted decks pending approval.")
+			.setDMPermission(false)
+			.setDefaultMemberPermissions(0)
+			.addStringOption(tournamentOption)
+			.toJSON();
+	}
+
+	protected override get logger(): Logger {
+		return this.#logger;
+	}
+
+	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+		autocompleteTournament(interaction);
+	}
+
+	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+		if (!interaction.inCachedGuild()) {
+			return;
+		}
+
+		const tournamentName = interaction.options.getString("tournament", true);
+		const tournament = await ManualTournament.findOneOrFail({
+			where: { name: tournamentName }
+		});
+
+		if (!(await authenticateHost(tournament, interaction))) {
+			// rejection messages handled in helper
+			return;
+		}
+
+		const decks = await ManualDeckSubmission.find({
+			where: { tournamentId: tournament.tournamentId, approved: false }
+		});
+		if (decks.length === 0) {
+			await interaction.reply({
+				content: `There are no players with pending decks in that tournament!`,
+				ephemeral: true
+			});
+			return;
+		}
+		const players = decks.map(d => userMention(d.discordId));
+
+		await interaction.reply(`${players.length} players are waiting for deck approval. List\n${players.join(", ")}`);
+	}
+}


### PR DESCRIPTION
## Description

New command: /queue
Lists players with decks awaiting approval

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
