### PR TITLE
Vary user registration message if already registered

### DIFF
--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -120,9 +120,12 @@ async function registerParticipant(
 		await setNickname(interaction.member, friendCode);
 	}
 	await player.save();
+
+	const userAction = player.deck ? "update your deck. It will need to be approved again afterwards" : "register";
+
 	await interaction.update({});
 	await interaction.user.send(
-		"Please upload screenshots of your decklist to register.\n**Important**: Please do not delete your message! This can make your decklist invisible to tournament hosts, which they may interpret as cheating."
+		`Please upload screenshots of your decklist to ${userAction}.\n**Important**: Please do not delete your message! This can make your decklist invisible to tournament hosts, which they may interpret as cheating.`
 	);
 }
 


### PR DESCRIPTION
## Description

If a user has already submitted a deck, it will talk to them about updating their deck, rather than registering. 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
