### PR TITLE
Add relevant emoji to all buttons

### DIFF
--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -6,7 +6,6 @@ import {
 	ButtonInteraction,
 	CacheType,
 	ChatInputCommandInteraction,
-	Emoji,
 	ModalBuilder,
 	ModalMessageModalSubmitInteraction,
 	SlashCommandBuilder,

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -6,6 +6,7 @@ import {
 	ButtonInteraction,
 	CacheType,
 	ChatInputCommandInteraction,
+	Emoji,
 	ModalBuilder,
 	ModalMessageModalSubmitInteraction,
 	SlashCommandBuilder,
@@ -91,15 +92,18 @@ export function generateDeckValidateButtons(tournament: ManualTournament): Actio
 		new ButtonBuilder()
 			.setCustomId(encodeCustomId("accept", tournament.tournamentId))
 			.setLabel("Accept")
-			.setStyle(ButtonStyle.Success),
+			.setStyle(ButtonStyle.Success)
+			.setEmoji("✅"),
 		new ButtonBuilder()
 			.setCustomId(encodeCustomId("quickaccept", tournament.tournamentId))
 			.setLabel("Accept (No Theme)")
-			.setStyle(ButtonStyle.Success),
+			.setStyle(ButtonStyle.Success)
+			.setEmoji("⏩"),
 		new ButtonBuilder()
 			.setCustomId(encodeCustomId("reject", tournament.tournamentId))
 			.setLabel("Reject")
 			.setStyle(ButtonStyle.Danger)
+			.setEmoji("❌")
 	);
 	return row;
 }

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -76,7 +76,7 @@ export class OpenCommand extends AutocompletableCommand {
 			.setCustomId("registerButton")
 			.setLabel("Click here to register!")
 			.setStyle(ButtonStyle.Success)
-			.setEmoji("✅");
+			.setEmoji("🎫");
 		row.addComponents(button);
 
 		const message = await send(interaction.client, tournament.publicChannel, {


### PR DESCRIPTION
## Description

Justification for each emoji:
- ✅ Accept Deck: Standard symbol for something being approved or good
- ⏩ Accept Deck without a theme: "Fast forward", signals that this is an abridged process for brevity's sake
- ❌ Reject Deck: Standard symbol for something being rejected or wrong. The boxed cross emoji is green, which clashes with the red button and could be confused with ✅.
- 🎫 Submit Deck: A ticket representing entry to the event, because it's for the user signing up. Changed from ✅ to be distinct, though I realise the latter isn't player-facing.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
