### PR TITLE
Drop players if they delete their submission message

### DIFF
--- a/src/database/orm/ManualDeckSubmission.ts
+++ b/src/database/orm/ManualDeckSubmission.ts
@@ -23,6 +23,10 @@ export class ManualDeckSubmission extends BaseEntity {
 	@Column({ default: false })
 	approved!: boolean;
 
+	/// The ID for the message containing the deck contents, so it can be monitored for deletion.
+	@Column({ length: 20 })
+	message!: string;
+
 	/// An optional custom label for the deck by hosts. Could be used for themes.
 	@Column({ type: "text", nullable: true })
 	label?: string;

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -10,6 +10,7 @@ import * as guildCreate from "./guildCreate";
 import * as guildMemberRemove from "./guildMemberRemove";
 import * as interaction from "./interaction";
 import * as messageCreate from "./messageCreate";
+import * as messageDelete from "./messageDelete";
 
 const logger = getLogger("events");
 
@@ -28,7 +29,7 @@ export function registerEvents(bot: Client, prefix: string, support: CommandSupp
 	bot.on("interactionCreate", interaction.makeHandler(support));
 	bot.on("messageCreate", messageCreate.makeHandler(bot, prefix, commands, support));
 	bot.on("guildMemberRemove", guildMemberRemove.makeHandler(support));
-	bot.on("messageDelete", message => support.database.cleanRegistration(message.channelId, message.id));
+	bot.on("messageDelete", messageDelete.makeHandler(bot, support));
 	bot.on("messageReactionAdd", async (reaction, user) => {
 		// reaction.me is true if the message is cached AND the bot reacted with the same emoji
 		if (user.id !== bot.user?.id && reaction.emoji.name === "✅") {

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -165,6 +165,7 @@ export async function onDirectMessage(
 		deck.approved = false;
 		deck.content = images.map(i => i.url).join("\n");
 		deck.participant = registering[0];
+		deck.message = msg.id;
 		await deck.save();
 
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
@@ -199,6 +200,7 @@ export async function onDirectMessage(
 		const d = submitted[0].deck!;
 		d.approved = false;
 		d.content = images.map(i => i.url).join("\n");
+		d.message = msg.id;
 		await d.save();
 
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -8,7 +8,7 @@ const logger = getLogger("messageDelete");
 
 export function makeHandler(bot: Client, support: CommandSupport): (msg: Message | PartialMessage) => Promise<void> {
 	return async function messageDelete(msg: Message | PartialMessage): Promise<void> {
-		support.database.cleanRegistration(msg.channelId, msg.id);
+		await support.database.cleanRegistration(msg.channelId, msg.id);
 		try {
 			// don't need the inner join on tournament because even - especially - mid-tournament, a deck dodger should be dropped
 			const deletedDecks = await ManualDeckSubmission.find({

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -1,0 +1,27 @@
+import { Client, Message, PartialMessage } from "discord.js";
+import { CommandSupport } from "../Command";
+import { ManualDeckSubmission } from "../database/orm";
+import { dropPlayer } from "../slash/database";
+import { getLogger } from "../util/logger";
+
+const logger = getLogger("messageDelete");
+
+export function makeHandler(bot: Client, support: CommandSupport): (msg: Message | PartialMessage) => Promise<void> {
+	return async function messageDelete(msg: Message | PartialMessage): Promise<void> {
+		support.database.cleanRegistration(msg.channelId, msg.id);
+		try {
+			// don't need the inner join on tournament because even - especially - mid-tournament, a deck dodger should be dropped
+			const deletedDecks = await ManualDeckSubmission.find({
+				where: { message: msg.id },
+				relations: ["tournament", "participant"]
+			});
+			for (const deck of deletedDecks) {
+				const guild = await bot.guilds.fetch(deck.tournament.owningDiscordServer);
+				const member = await guild.members.fetch(deck.discordId);
+				await dropPlayer(deck.tournament, deck.participant, member);
+			}
+		} catch (e) {
+			logger.error(e);
+		}
+	};
+}

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -122,7 +122,7 @@ async function registerParticipant(
 	await player.save();
 	await interaction.update({});
 	await interaction.user.send(
-		"Please upload screenshots of your decklist to register.\n**Important**: Please do not delete your message! This can make your decklist invisible to tournament hosts, which they may interpret as cheating."
+		"Please upload screenshots of your decklist to register.\n**Important**: Please do not delete your message! You will be dropped for cheating, as this can make your decklist invisible to hosts."
 	);
 }
 

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -135,7 +135,7 @@ async function registerParticipant(
 
 	await interaction.update({});
 	await interaction.user.send(
-		"Please upload screenshots of your decklist to ${userAction}.\n**Important**: Please do not delete your message! You will be dropped for cheating, as this can make your decklist invisible to hosts."
+		`Please upload screenshots of your decklist to ${userAction}.\n**Important**: Please do not delete your message! You will be dropped for cheating, as this can make your decklist invisible to hosts.`
 	);
 }
 

--- a/test/database.ts
+++ b/test/database.ts
@@ -39,6 +39,7 @@ describe("Entities for manual tournaments", () => {
 		const deck = new ManualDeckSubmission();
 		deck.participant = participant;
 		deck.content = "foo";
+		deck.message = "1069831269388660796";
 		await deck.save();
 		expect(deck.tournamentId).to.be.greaterThan(0);
 		expect(deck.discordId).to.be.equal("0");


### PR DESCRIPTION
## Description

Adds `ManualDeckSubmission.message` to the database and implements a `messageDelete` event handler. 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
