### PR TITLE
Allow dropping a user not in the server

### DIFF
--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -6,6 +6,7 @@ import {
 	GuildMember,
 	PartialGuildMember,
 	SlashCommandStringOption,
+	User,
 	userMention
 } from "discord.js";
 import { ILike } from "typeorm";
@@ -97,12 +98,15 @@ export function checkParticipantCap(
 export async function dropPlayer(
 	tournament: ManualTournament,
 	player: ManualParticipant,
-	member: GuildMember | PartialGuildMember,
+	member: GuildMember | PartialGuildMember | User,
 	interaction?: ChatInputCommandInteraction | ContextMenuCommandInteraction
 ): Promise<void> {
 	// don't use participantRoleProvider because it's made for ChallongeTournaments with exposed ids
 	// TODO: fix above? also handle when can't find role
-	await member.roles.remove(tournament.participantRole);
+	if ("roles" in member) {
+		await member.roles.remove(tournament.participantRole);
+	}
+
 	if (tournament.status === TournamentStatus.PREPARING) {
 		await player.remove();
 	} else {
@@ -118,7 +122,7 @@ export async function dropPlayer(
 		await member.send(playerMessage);
 	}
 
-	const hostMessage = `${userMention(member.user.id)} has been dropped from ${tournament.name}.`;
+	const hostMessage = `${userMention(member.id)} has been dropped from ${tournament.name}.`;
 
 	if (interaction && interaction.commandName !== "drop") {
 		await interaction.reply(hostMessage);

--- a/src/slash/drop.ts
+++ b/src/slash/drop.ts
@@ -46,8 +46,6 @@ export class DropCommand extends AutocompletableCommand {
 			// rejection messages handled in helper
 			return;
 		}
-
-		const member = interaction.member || interaction.guild.members.fetch(interaction.user.id);
-		await dropPlayer(tournament, player, member, interaction);
+		await dropPlayer(tournament, player, interaction.member, interaction);
 	}
 }

--- a/src/slash/forcedrop.ts
+++ b/src/slash/forcedrop.ts
@@ -5,7 +5,6 @@ import {
 	chatInputApplicationCommandMention,
 	ChatInputCommandInteraction,
 	ContextMenuCommandBuilder,
-	GuildMember,
 	SlashCommandBuilder,
 	UserContextMenuCommandInteraction
 } from "discord.js";

--- a/src/slash/forcedrop.ts
+++ b/src/slash/forcedrop.ts
@@ -66,6 +66,7 @@ export class ForceDropSlashCommand extends AutocompletableCommand {
 			return;
 		}
 
+		// we use the cache instead of fetching from rest because the fetch will throw if the user is not in the server
 		const member = interaction.guild.members.cache.get(user.id);
 		await dropPlayer(tournament, player, member || user, interaction);
 	}

--- a/src/slash/forcedrop.ts
+++ b/src/slash/forcedrop.ts
@@ -5,6 +5,7 @@ import {
 	chatInputApplicationCommandMention,
 	ChatInputCommandInteraction,
 	ContextMenuCommandBuilder,
+	GuildMember,
 	SlashCommandBuilder,
 	UserContextMenuCommandInteraction
 } from "discord.js";
@@ -64,9 +65,13 @@ export class ForceDropSlashCommand extends AutocompletableCommand {
 			});
 			return;
 		}
-
-		const member = await interaction.guild.members.fetch({ user: user });
-		await dropPlayer(tournament, player, member, interaction);
+		let member: GuildMember | undefined;
+		try {
+			member = await interaction.guild.members.fetch({ user: user });
+		} finally {
+			// disregard error because it's just "no member found"
+			await dropPlayer(tournament, player, member || user, interaction);
+		}
 	}
 }
 

--- a/src/slash/forcedrop.ts
+++ b/src/slash/forcedrop.ts
@@ -65,13 +65,9 @@ export class ForceDropSlashCommand extends AutocompletableCommand {
 			});
 			return;
 		}
-		let member: GuildMember | undefined;
-		try {
-			member = await interaction.guild.members.fetch({ user: user });
-		} finally {
-			// disregard error because it's just "no member found"
-			await dropPlayer(tournament, player, member || user, interaction);
-		}
+
+		const member = interaction.guild.members.cache.get(user.id);
+		await dropPlayer(tournament, player, member || user, interaction);
 	}
 }
 


### PR DESCRIPTION
## Description

Handle when their Member data doesn't exist
Relevant to #465, though doesn't close it entirely

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
