### PR TITLE
Assign participant role when approved, remove otherwise

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -201,6 +201,14 @@ export async function onDirectMessage(
 		d.content = images.map(i => i.url).join("\n");
 		await d.save();
 
+		await msg.client.guilds.cache
+			.get(submitted[0].tournament.owningDiscordServer)
+			?.members.removeRole({
+				user: msg.author.id,
+				role: submitted[0].tournament.participantRole,
+				reason: "Deck resubmitted."
+			});
+
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
 		outMessage += `\n${d.content}`;
 

--- a/src/slash/create.ts
+++ b/src/slash/create.ts
@@ -60,7 +60,11 @@ export class CreateCommand extends SlashCommand {
 		tournament.hosts = [interaction.user.id];
 		tournament.requireFriendCode = requireCode;
 
-		const playerRole = await interaction.guild.roles.create({ name: `${tournament.name} Participant` });
+		const playerRole = await interaction.guild.roles.create({
+			name: `${tournament.name} Participant`,
+			color: 0xe67e22,
+			reason: `Automatically created by Emcee for ${tournament.name}`
+		});
 
 		tournament.participantRole = playerRole.id;
 

--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -102,7 +102,7 @@ export async function dropPlayer(
 ): Promise<void> {
 	// don't use participantRoleProvider because it's made for ChallongeTournaments with exposed ids
 	// TODO: fix above? also handle when can't find role
-	await member.roles.remove(tournament.participantRole);
+	await member.roles.remove(tournament.participantRole, "Dropped from tournament.");
 	if (tournament.status === TournamentStatus.PREPARING) {
 		await player.remove();
 	} else {

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -144,9 +144,12 @@ export class QuickAcceptButtonHandler implements ButtonClickHandler {
 		await deck.save();
 
 		const tournament = await ManualTournament.findOneOrFail({ where: { tournamentId } });
-		// provide feedback to player
+		await interaction.guild!.members.addRole({
+			user: interaction.user.id,
+			role: tournament.participantRole,
+			reason: `Deck approved by ${interaction.user.tag}`
+		});
 		await player.send(`Your deck has been accepted by the hosts! You are now registered for ${tournament.name}.`);
-		// TODO: Give player participant role
 		// log success to TO
 		await interaction.reply(
 			`${userMention(player.id)}'s deck for ${tournament.name} has been approved by ${userMention(
@@ -196,9 +199,12 @@ export class AcceptLabelModal implements MessageModalSubmitHandler {
 		await deck.save();
 
 		const tournament = await ManualTournament.findOneOrFail({ where: { tournamentId } });
-		// provide feedback to player
+		await interaction.guild!.members.addRole({
+			user: interaction.user.id,
+			role: tournament.participantRole,
+			reason: `Deck approved by ${interaction.user.tag}`
+		});
 		await player.send(`Your deck has been accepted by the hosts! You are now registered for ${tournament.name}.`);
-		// TODO: Give player participant role
 		// log success to TO
 		await interaction.reply(
 			`${userMention(player.id)}'s deck for ${tournament.name} has been approved by ${userMention(

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -125,7 +125,7 @@ export class AcceptButtonHandler implements ButtonClickHandler {
 export class QuickAcceptButtonHandler implements ButtonClickHandler {
 	readonly buttonIds = ["quickaccept"];
 
-	async click(interaction: ButtonInteraction, ...args: string[]): Promise<void> {
+	async click(interaction: ButtonInteraction<"cached">, ...args: string[]): Promise<void> {
 		// c/p from AcceptLabelModalHandler
 		const tournamentIdString = args[0];
 		const tournamentId = parseInt(tournamentIdString, 10);
@@ -140,7 +140,7 @@ export class QuickAcceptButtonHandler implements ButtonClickHandler {
 		await deck.save();
 
 		const tournament = await ManualTournament.findOneOrFail({ where: { tournamentId } });
-		await interaction.guild!.members.addRole({
+		await interaction.guild.members.addRole({
 			user: interaction.user.id,
 			role: tournament.participantRole,
 			reason: `Deck approved by ${interaction.user.tag}`
@@ -177,7 +177,7 @@ export class RejectButtonHandler implements ButtonClickHandler {
 export class AcceptLabelModal implements MessageModalSubmitHandler {
 	readonly modalIds = ["acceptModal"];
 
-	async submit(interaction: ModalMessageModalSubmitInteraction, ...args: string[]): Promise<void> {
+	async submit(interaction: ModalMessageModalSubmitInteraction<"cached">, ...args: string[]): Promise<void> {
 		const tournamentIdString = args[0];
 		const tournamentId = parseInt(tournamentIdString, 10);
 		const deck = await ManualDeckSubmission.findOneOrFail({
@@ -195,7 +195,7 @@ export class AcceptLabelModal implements MessageModalSubmitHandler {
 		await deck.save();
 
 		const tournament = await ManualTournament.findOneOrFail({ where: { tournamentId } });
-		await interaction.guild!.members.addRole({
+		await interaction.guild.members.addRole({
 			user: interaction.user.id,
 			role: tournament.participantRole,
 			reason: `Deck approved by ${interaction.user.tag}`


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

Role colour same as before.
Add audit log reasons.
Will remove guild non-null assertion when the cached guild guard is enforced for all interactions.
Will double-check later in polish because this may behave unexpectedly with multiple presses on buttons that aren't meant to be.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
