### PR TITLE
Add cached guild type guard to all interactions

### DIFF
--- a/src/SlashCommand.ts
+++ b/src/SlashCommand.ts
@@ -3,13 +3,14 @@ import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
 import {
 	AutocompleteInteraction,
 	ButtonInteraction,
+	CacheType,
 	ChatInputCommandInteraction,
 	ModalMessageModalSubmitInteraction
 } from "discord.js";
 import { serialiseInteraction } from "./util";
 import { Logger } from "./util/logger";
 
-export abstract class SlashCommand {
+export abstract class SlashCommand<Cached extends CacheType = CacheType> {
 	static get meta(): RESTPostAPIApplicationCommandsJSONBody {
 		throw new Error("Not implemented");
 	}
@@ -27,7 +28,7 @@ export abstract class SlashCommand {
 	 *
 	 * @param interaction
 	 */
-	protected abstract execute(interaction: ChatInputCommandInteraction): Promise<void>;
+	protected abstract execute(interaction: ChatInputCommandInteraction<Cached>): Promise<void>;
 
 	/**
 	 * Run this command in response to user interaction from start to finish.
@@ -35,7 +36,7 @@ export abstract class SlashCommand {
 	 *
 	 * @param interaction
 	 */
-	async run(interaction: ChatInputCommandInteraction): Promise<void> {
+	async run(interaction: ChatInputCommandInteraction<Cached>): Promise<void> {
 		try {
 			this.logger.verbose(
 				serialiseInteraction(interaction, { event: "attempt", ping: interaction.client.ws.ping })
@@ -59,16 +60,16 @@ export abstract class SlashCommand {
 	}
 }
 
-export abstract class AutocompletableCommand extends SlashCommand {
-	abstract autocomplete(interaction: AutocompleteInteraction): Promise<void>;
+export abstract class AutocompletableCommand<Cached extends CacheType = CacheType> extends SlashCommand<Cached> {
+	abstract autocomplete(interaction: AutocompleteInteraction<Cached>): Promise<void>;
 }
 
-export interface ButtonClickHandler {
+export interface ButtonClickHandler<Cached extends CacheType = CacheType> {
 	readonly buttonIds: string[];
-	click(interaction: ButtonInteraction, ...args: string[]): Promise<void>;
+	click(interaction: ButtonInteraction<Cached>, ...args: string[]): Promise<void>;
 }
 
-export interface MessageModalSubmitHandler {
+export interface MessageModalSubmitHandler<Cached extends CacheType = CacheType> {
 	readonly modalIds: string[];
-	submit(interaction: ModalMessageModalSubmitInteraction, ...args: string[]): Promise<void>;
+	submit(interaction: ModalMessageModalSubmitInteraction<Cached>, ...args: string[]): Promise<void>;
 }

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -17,15 +17,15 @@ import { FinishCommand } from "../slash/finish";
 import { ForceDropContextCommand, ForceDropSlashCommand } from "../slash/forcedrop";
 import { HostCommand } from "../slash/host";
 import { InfoCommand } from "../slash/info";
-import { FriendCodeModalHandler, OpenCommand, RegisterButtonHandler } from "../slash/open";
 import { ListCommand } from "../slash/list";
+import { FriendCodeModalHandler, OpenCommand, RegisterButtonHandler } from "../slash/open";
+import { QueueCommand } from "../slash/queue";
 import { StartCommand } from "../slash/start";
 import { TimerCommand } from "../slash/timer";
 import { UpdateCommand } from "../slash/update";
 import { AutocompletableCommand, ButtonClickHandler, MessageModalSubmitHandler, SlashCommand } from "../SlashCommand";
 import { serialiseInteraction } from "../util";
 import { getLogger } from "../util/logger";
-import { QueueCommand } from "../slash/queue";
 
 const logger = getLogger("interaction");
 
@@ -86,6 +86,9 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 	}
 
 	return async function interactionCreate(interaction: Interaction): Promise<void> {
+		if (!interaction.inCachedGuild()) {
+			return;
+		}
 		if (interaction.isChatInputCommand()) {
 			logger.verbose(serialiseInteraction(interaction));
 			await commands.get(interaction.commandName)?.run(interaction);

--- a/src/slash/channel.ts
+++ b/src/slash/channel.ts
@@ -1,17 +1,11 @@
 import { ChannelType, RESTPostAPIApplicationCommandsJSONBody, Snowflake } from "discord-api-types/v10";
-import {
-	AutocompleteInteraction,
-	CacheType,
-	channelMention,
-	ChatInputCommandInteraction,
-	SlashCommandBuilder
-} from "discord.js";
+import { AutocompleteInteraction, channelMention, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
 import { getLogger, Logger } from "../util/logger";
 import { authenticateHost, autocompleteTournament, tournamentOption } from "./database";
 
-export class ChannelCommand extends AutocompletableCommand {
+export class ChannelCommand extends AutocompletableCommand<"cached"> {
 	#logger = getLogger("command:channel");
 
 	constructor() {
@@ -45,7 +39,7 @@ export class ChannelCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 

--- a/src/slash/channel.ts
+++ b/src/slash/channel.ts
@@ -72,7 +72,7 @@ export class ChannelCommand extends AutocompletableCommand<"cached"> {
 		return;
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({ where: { name: tournamentName } });
 

--- a/src/slash/create.ts
+++ b/src/slash/create.ts
@@ -36,11 +36,7 @@ export class CreateCommand extends SlashCommand {
 		return this.#logger;
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
-
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		// Should be replaced by the built-in system
 		const toRole = await this.organiserRole.get(interaction.guild);
 		if (!interaction.member.roles.cache.has(toRole)) {

--- a/src/slash/csv.ts
+++ b/src/slash/csv.ts
@@ -42,7 +42,7 @@ export class CsvCommand extends AutocompletableCommand {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		await interaction.deferReply();
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({ where: { name: tournamentName } });

--- a/src/slash/csv.ts
+++ b/src/slash/csv.ts
@@ -1,11 +1,11 @@
+import * as csv from "@fast-csv/format";
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
-import { AutocompleteInteraction, CacheType, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { AutocompleteInteraction, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
+import { username } from "../util/discord";
 import { getLogger, Logger } from "../util/logger";
 import { authenticateHost, autocompleteTournament, tournamentOption } from "./database";
-import * as csv from "@fast-csv/format";
-import { username } from "../util/discord";
 
 export class CsvCommand extends AutocompletableCommand {
 	#logger = getLogger("command:csv");
@@ -38,7 +38,7 @@ export class CsvCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 

--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -35,13 +35,10 @@ export async function autocompleteTournament(interaction: AutocompleteInteractio
 
 export async function authenticateHost(
 	tournament: ManualTournament,
-	interaction: ChatInputCommandInteraction | ContextMenuCommandInteraction,
+	interaction: ChatInputCommandInteraction<"cached"> | ContextMenuCommandInteraction<"cached">,
 	isDeferred = false
 ): Promise<boolean> {
 	const func = isDeferred ? "editReply" : "reply";
-	if (!interaction.inCachedGuild()) {
-		return false;
-	}
 	if (tournament.owningDiscordServer !== interaction.guildId) {
 		// ephemeral response preferred but deferred commands have to stay consistent and should be public in success
 		await interaction[func]({ content: `That tournament isn't in this server.`, ephemeral: !isDeferred });
@@ -56,11 +53,8 @@ export async function authenticateHost(
 
 export async function authenticatePlayer(
 	tournament: ManualTournament,
-	interaction: ChatInputCommandInteraction
+	interaction: ChatInputCommandInteraction<"cached">
 ): Promise<ManualParticipant | undefined> {
-	if (!interaction.inCachedGuild()) {
-		return;
-	}
 	if (tournament.owningDiscordServer !== interaction.guildId) {
 		await interaction.reply({ content: `That tournament isn't in this server.`, ephemeral: true });
 		return;

--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -1,6 +1,5 @@
 import {
 	AutocompleteInteraction,
-	CacheType,
 	ChatInputCommandInteraction,
 	ContextMenuCommandInteraction,
 	GuildMember,
@@ -19,10 +18,7 @@ export const tournamentOption = new SlashCommandStringOption()
 	.setRequired(true)
 	.setAutocomplete(true);
 
-export async function autocompleteTournament(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
-	if (!interaction.inCachedGuild()) {
-		return;
-	}
+export async function autocompleteTournament(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 	const partialName = interaction.options.getFocused();
 	const owningDiscordServer = interaction.guildId;
 	const tournaments = await ManualTournament.find({

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -45,7 +45,7 @@ export class DeckCommand extends AutocompletableCommand {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName }

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -4,7 +4,6 @@ import {
 	AutocompleteInteraction,
 	ButtonBuilder,
 	ButtonInteraction,
-	CacheType,
 	ChatInputCommandInteraction,
 	ModalBuilder,
 	ModalMessageModalSubmitInteraction,
@@ -42,14 +41,11 @@ export class DeckCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 
 	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName }

--- a/src/slash/drop.ts
+++ b/src/slash/drop.ts
@@ -1,5 +1,5 @@
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
-import { AutocompleteInteraction, CacheType, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { AutocompleteInteraction, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
 import { getLogger, Logger } from "../util/logger";
@@ -26,14 +26,11 @@ export class DropCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName },

--- a/src/slash/finish.ts
+++ b/src/slash/finish.ts
@@ -1,11 +1,5 @@
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
-import {
-	AutocompleteInteraction,
-	CacheType,
-	ChatInputCommandInteraction,
-	roleMention,
-	SlashCommandBuilder
-} from "discord.js";
+import { AutocompleteInteraction, ChatInputCommandInteraction, roleMention, SlashCommandBuilder } from "discord.js";
 import { TournamentStatus } from "../database/interface";
 import { ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
@@ -34,14 +28,11 @@ export class FinishCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({ where: { name: tournamentName } });
 

--- a/src/slash/forcedrop.ts
+++ b/src/slash/forcedrop.ts
@@ -1,7 +1,6 @@
 import { ApplicationCommandType, RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
 import {
 	AutocompleteInteraction,
-	CacheType,
 	chatInputApplicationCommandMention,
 	ChatInputCommandInteraction,
 	ContextMenuCommandBuilder,
@@ -36,14 +35,11 @@ export class ForceDropSlashCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName },
@@ -85,11 +81,7 @@ export class ForceDropContextCommand extends ContextCommand {
 		return this.#logger;
 	}
 
-	protected override async execute(interaction: UserContextMenuCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
-
+	protected override async execute(interaction: UserContextMenuCommandInteraction<"cached">): Promise<void> {
 		// more useful than user since we need to manage roles, still has the id
 		const member = interaction.targetMember;
 

--- a/src/slash/host.ts
+++ b/src/slash/host.ts
@@ -49,7 +49,7 @@ export class HostCommand extends AutocompletableCommand {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({ where: { name: tournamentName } });
 		const host = interaction.options.getUser("user", true);

--- a/src/slash/host.ts
+++ b/src/slash/host.ts
@@ -1,7 +1,6 @@
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
 import {
 	AutocompleteInteraction,
-	CacheType,
 	ChatInputCommandInteraction,
 	SlashCommandBuilder,
 	SlashCommandSubcommandBuilder,
@@ -46,7 +45,7 @@ export class HostCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 

--- a/src/slash/info.ts
+++ b/src/slash/info.ts
@@ -1,7 +1,6 @@
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
 import {
 	AutocompleteInteraction,
-	CacheType,
 	ChatInputCommandInteraction,
 	EmbedBuilder,
 	EmbedField,
@@ -33,7 +32,7 @@ export class InfoCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 

--- a/src/slash/info.ts
+++ b/src/slash/info.ts
@@ -36,7 +36,7 @@ export class InfoCommand extends AutocompletableCommand {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({ where: { name: tournamentName } });
 

--- a/src/slash/list.ts
+++ b/src/slash/list.ts
@@ -26,11 +26,7 @@ export class ListCommand extends SlashCommand {
 		return this.#logger;
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
-
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		// Should be replaced by the built-in system
 		const toRole = await this.organiserRole.get(interaction.guild);
 		if (!interaction.member.roles.cache.has(toRole)) {

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -51,7 +51,7 @@ export class OpenCommand extends AutocompletableCommand {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({ where: { name: tournamentName } });
 

--- a/src/slash/queue.ts
+++ b/src/slash/queue.ts
@@ -1,11 +1,5 @@
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
-import {
-	AutocompleteInteraction,
-	CacheType,
-	ChatInputCommandInteraction,
-	SlashCommandBuilder,
-	userMention
-} from "discord.js";
+import { AutocompleteInteraction, ChatInputCommandInteraction, SlashCommandBuilder, userMention } from "discord.js";
 import { ManualDeckSubmission, ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
 import { getLogger, Logger } from "../util/logger";
@@ -32,15 +26,11 @@ export class QueueCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 
 	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
-
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName }

--- a/src/slash/queue.ts
+++ b/src/slash/queue.ts
@@ -30,7 +30,7 @@ export class QueueCommand extends AutocompletableCommand {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName }

--- a/src/slash/start.ts
+++ b/src/slash/start.ts
@@ -1,5 +1,5 @@
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
-import { AutocompleteInteraction, CacheType, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { AutocompleteInteraction, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { TournamentStatus } from "../database/interface";
 import { ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
@@ -27,15 +27,11 @@ export class StartCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
-
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName },

--- a/src/slash/timer.ts
+++ b/src/slash/timer.ts
@@ -39,10 +39,7 @@ export class TimerCommand extends SlashCommand {
 		return this.#logger;
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-		if (!interaction.inCachedGuild()) {
-			return;
-		}
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		// Should be replaced by the built-in system
 		const role = await this.organiserRole.get(interaction.guild);
 		if (!interaction.member.roles.cache.has(role)) {

--- a/src/slash/update.ts
+++ b/src/slash/update.ts
@@ -1,5 +1,5 @@
 import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
-import { AutocompleteInteraction, CacheType, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { AutocompleteInteraction, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
 import { getLogger, Logger } from "../util/logger";
@@ -44,7 +44,7 @@ export class UpdateCommand extends AutocompletableCommand {
 		return this.#logger;
 	}
 
-	override async autocomplete(interaction: AutocompleteInteraction<CacheType>): Promise<void> {
+	override async autocomplete(interaction: AutocompleteInteraction<"cached">): Promise<void> {
 		autocompleteTournament(interaction);
 	}
 

--- a/src/slash/update.ts
+++ b/src/slash/update.ts
@@ -48,7 +48,7 @@ export class UpdateCommand extends AutocompletableCommand {
 		autocompleteTournament(interaction);
 	}
 
-	protected override async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName },


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

It seems inheritance on a generic type is poorly enforced, or because the type parameter "extends" a UnionType

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
