### PR TITLE
Fix deck resubmission process

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -171,9 +171,9 @@ export async function onDirectMessage(
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
 		outMessage += `\n${deck.content}`;
 
-		const row = generateDeckValidateButtons(deck);
-		if (deck.tournament.privateChannel) {
-			await send(msg.client, deck.tournament.privateChannel, {
+		const row = generateDeckValidateButtons(registering[0].tournament.tournamentId, msg.id);
+		if (registering[0].tournament.privateChannel) {
+			await send(msg.client, registering[0].tournament.privateChannel, {
 				content: outMessage,
 				components: [row]
 			});
@@ -212,7 +212,7 @@ export async function onDirectMessage(
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
 		outMessage += `\n${deck.content}`;
 
-		const row = generateDeckValidateButtons(deck);
+		const row = generateDeckValidateButtons(submitted[0].tournament.tournamentId, msg.id);
 		if (submitted[0].tournament.privateChannel) {
 			await send(msg.client, submitted[0].tournament.privateChannel, {
 				content: outMessage,

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -171,9 +171,9 @@ export async function onDirectMessage(
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
 		outMessage += `\n${deck.content}`;
 
-		const row = generateDeckValidateButtons(registering[0].tournament);
-		if (deck.participant.tournament.privateChannel) {
-			await send(msg.client, deck.participant.tournament.privateChannel, {
+		const row = generateDeckValidateButtons(deck);
+		if (deck.tournament.privateChannel) {
+			await send(msg.client, deck.tournament.privateChannel, {
 				content: outMessage,
 				components: [row]
 			});
@@ -197,24 +197,22 @@ export async function onDirectMessage(
 		}
 		// a submitted player should definitely have a deck
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const d = submitted[0].deck!;
-		d.approved = false;
-		d.content = images.map(i => i.url).join("\n");
-		d.message = msg.id;
-		await d.save();
+		const deck = submitted[0].deck!;
+		deck.approved = false;
+		deck.content = images.map(i => i.url).join("\n");
+		deck.message = msg.id;
+		await deck.save();
 
-		await msg.client.guilds.cache
-			.get(submitted[0].tournament.owningDiscordServer)
-			?.members.removeRole({
-				user: msg.author.id,
-				role: submitted[0].tournament.participantRole,
-				reason: "Deck resubmitted."
-			});
+		await msg.client.guilds.cache.get(submitted[0].tournament.owningDiscordServer)?.members.removeRole({
+			user: msg.author.id,
+			role: submitted[0].tournament.participantRole,
+			reason: "Deck resubmitted."
+		});
 
 		let outMessage = `__**${userMention(msg.author.id)}'s deck**__:`;
-		outMessage += `\n${d.content}`;
+		outMessage += `\n${deck.content}`;
 
-		const row = generateDeckValidateButtons(submitted[0].tournament);
+		const row = generateDeckValidateButtons(deck);
 		if (submitted[0].tournament.privateChannel) {
 			await send(msg.client, submitted[0].tournament.privateChannel, {
 				content: outMessage,

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -77,25 +77,25 @@ export class DeckCommand extends AutocompletableCommand {
 			return;
 		}
 
-		const row = generateDeckValidateButtons(playerDeck);
+		const row = generateDeckValidateButtons(tournament.tournamentId, playerDeck.message);
 		await interaction.reply({ content: outMessage, components: [row] });
 	}
 }
 
-export function generateDeckValidateButtons(deck: ManualDeckSubmission): ActionRowBuilder<ButtonBuilder> {
+export function generateDeckValidateButtons(tournamentId: number, messageId: string): ActionRowBuilder<ButtonBuilder> {
 	const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
 		new ButtonBuilder()
-			.setCustomId(encodeCustomId("accept", deck.tournamentId, deck.message))
+			.setCustomId(encodeCustomId("accept", tournamentId, messageId))
 			.setLabel("Accept")
 			.setStyle(ButtonStyle.Success)
 			.setEmoji("✅"),
 		new ButtonBuilder()
-			.setCustomId(encodeCustomId("quickaccept", deck.tournamentId, deck.message))
+			.setCustomId(encodeCustomId("quickaccept", tournamentId, messageId))
 			.setLabel("Accept (No Theme)")
 			.setStyle(ButtonStyle.Success)
 			.setEmoji("⏩"),
 		new ButtonBuilder()
-			.setCustomId(encodeCustomId("reject", deck.tournamentId, deck.message))
+			.setCustomId(encodeCustomId("reject", tournamentId, messageId))
 			.setLabel("Reject")
 			.setStyle(ButtonStyle.Danger)
 			.setEmoji("❌")

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -77,25 +77,25 @@ export class DeckCommand extends AutocompletableCommand {
 			return;
 		}
 
-		const row = generateDeckValidateButtons(tournament);
+		const row = generateDeckValidateButtons(playerDeck);
 		await interaction.reply({ content: outMessage, components: [row] });
 	}
 }
 
-export function generateDeckValidateButtons(tournament: ManualTournament): ActionRowBuilder<ButtonBuilder> {
+export function generateDeckValidateButtons(deck: ManualDeckSubmission): ActionRowBuilder<ButtonBuilder> {
 	const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
 		new ButtonBuilder()
-			.setCustomId(encodeCustomId("accept", tournament.tournamentId))
+			.setCustomId(encodeCustomId("accept", deck.tournamentId, deck.message))
 			.setLabel("Accept")
 			.setStyle(ButtonStyle.Success)
 			.setEmoji("✅"),
 		new ButtonBuilder()
-			.setCustomId(encodeCustomId("quickaccept", tournament.tournamentId))
+			.setCustomId(encodeCustomId("quickaccept", deck.tournamentId, deck.message))
 			.setLabel("Accept (No Theme)")
 			.setStyle(ButtonStyle.Success)
 			.setEmoji("⏩"),
 		new ButtonBuilder()
-			.setCustomId(encodeCustomId("reject", tournament.tournamentId))
+			.setCustomId(encodeCustomId("reject", deck.tournamentId, deck.message))
 			.setLabel("Reject")
 			.setStyle(ButtonStyle.Danger)
 			.setEmoji("❌")

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -107,7 +107,18 @@ export class AcceptButtonHandler implements ButtonClickHandler {
 	readonly buttonIds = ["accept"];
 
 	async click(interaction: ButtonInteraction, ...args: string[]): Promise<void> {
-		const tournamentIdString = args[0];
+		const [tournamentIdString, sourceMessageId] = args;
+		const tournamentId = parseInt(tournamentIdString, 10);
+		const deck = await ManualDeckSubmission.findOneOrFail({
+			where: {
+				discordId: interaction.user.id,
+				tournamentId
+			}
+		});
+		if (deck.message !== sourceMessageId) {
+			await interaction.reply(`This deck is outdated, the player has submitted a newer one!`);
+			return;
+		}
 		const modal = new ModalBuilder()
 			.setCustomId(encodeCustomId("acceptModal", tournamentIdString))
 			.setTitle("Accept Deck");
@@ -127,7 +138,7 @@ export class QuickAcceptButtonHandler implements ButtonClickHandler {
 
 	async click(interaction: ButtonInteraction<"cached">, ...args: string[]): Promise<void> {
 		// c/p from AcceptLabelModalHandler
-		const tournamentIdString = args[0];
+		const [tournamentIdString, sourceMessageId] = args;
 		const tournamentId = parseInt(tournamentIdString, 10);
 		const deck = await ManualDeckSubmission.findOneOrFail({
 			where: {
@@ -135,6 +146,10 @@ export class QuickAcceptButtonHandler implements ButtonClickHandler {
 				tournamentId
 			}
 		});
+		if (deck.message !== sourceMessageId) {
+			await interaction.reply(`This deck is outdated, the player has submitted a newer one!`);
+			return;
+		}
 		const player = await interaction.client.users.fetch(deck.discordId);
 		deck.approved = true;
 		await deck.save();
@@ -159,7 +174,18 @@ export class RejectButtonHandler implements ButtonClickHandler {
 	readonly buttonIds = ["reject"];
 
 	async click(interaction: ButtonInteraction, ...args: string[]): Promise<void> {
-		const tournamentIdString = args[0];
+		const [tournamentIdString, sourceMessageId] = args;
+		const tournamentId = parseInt(tournamentIdString, 10);
+		const deck = await ManualDeckSubmission.findOneOrFail({
+			where: {
+				discordId: interaction.user.id,
+				tournamentId
+			}
+		});
+		if (deck.message !== sourceMessageId) {
+			await interaction.reply(`This deck is outdated, the player has submitted a newer one!`);
+			return;
+		}
 		const modal = new ModalBuilder()
 			.setCustomId(encodeCustomId("rejectModal", tournamentIdString))
 			.setTitle("Reject Deck");

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -120,9 +120,6 @@ async function registerParticipant(
 	tournament: ManualTournament,
 	friendCode?: number
 ): Promise<void> {
-	// use js find instead of database query because we already have the tournament
-	const oldDeck = !!tournament.decks.find(d => d.discordId === interaction.user.id);
-
 	const player: ManualParticipant = new ManualParticipant();
 	player.discordId = interaction.user.id;
 	player.tournament = tournament;
@@ -131,12 +128,9 @@ async function registerParticipant(
 		await setNickname(interaction.member, friendCode);
 	}
 	await player.save();
-
-	const userAction = oldDeck ? "update your deck. It will need to be approved again afterwards" : "register";
-
 	await interaction.update({});
 	await interaction.user.send(
-		`Please upload screenshots of your decklist to ${userAction}.\n**Important**: Please do not delete your message! You will be dropped for cheating, as this can make your decklist invisible to hosts.`
+		`Please upload screenshots of your decklist to register.\n**Important**: Please do not delete your message! You will be dropped for cheating, as this can make your decklist invisible to hosts.`
 	);
 }
 

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -178,7 +178,8 @@ export class RegisterButtonHandler implements ButtonClickHandler {
 			where: { tournamentId: tournament.tournamentId, discordId: interaction.user.id }
 		});
 		if (participant.length) {
-			await interaction.reply(
+			await interaction.update({});
+			await interaction.user.send(
 				`You are already registered for this tournament! You can submit a new deck by just sending a new message.`
 			);
 			return;

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -180,6 +180,15 @@ export class RegisterButtonHandler implements ButtonClickHandler {
 			});
 			return;
 		}
+		const participant = await ManualParticipant.find({
+			where: { tournamentId: tournament.tournamentId, discordId: interaction.user.id }
+		});
+		if (participant.length) {
+			await interaction.reply(
+				`You are already registered for this tournament! You can submit a new deck by just sending a new message.`
+			);
+			return;
+		}
 		if (tournament.requireFriendCode) {
 			const modal = new ModalBuilder().setCustomId("registerModal").setTitle(`Register for ${tournament.name}`);
 			const deckLabelInput = new TextInputBuilder()

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -120,6 +120,9 @@ async function registerParticipant(
 	tournament: ManualTournament,
 	friendCode?: number
 ): Promise<void> {
+	// use js find instead of database query because we already have the tournament
+	const oldDeck = !!tournament.decks.find(d => d.discordId === interaction.user.id);
+
 	const player: ManualParticipant = new ManualParticipant();
 	player.discordId = interaction.user.id;
 	player.tournament = tournament;
@@ -129,7 +132,7 @@ async function registerParticipant(
 	}
 	await player.save();
 
-	const userAction = player.deck ? "update your deck. It will need to be approved again afterwards" : "register";
+	const userAction = oldDeck ? "update your deck. It will need to be approved again afterwards" : "register";
 
 	await interaction.update({});
 	await interaction.user.send(


### PR DESCRIPTION
## Description

Bar players from clicking the button to register when already registered
On deck resubmission through DM, disable validation on previous deck

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
