### PR TITLE
Fix friend code nicknames

### DIFF
--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -106,7 +106,7 @@ export class OpenCommand extends AutocompletableCommand {
 }
 
 export function formatFriendCode(friendCode: number): string {
-	const friendString = friendCode.toString(10);
+	const friendString = friendCode.toString(10).padStart(9, "0");
 	return `${friendString.slice(0, 3)}-${friendString.slice(3, 6)}-${friendString.slice(6, 9)}`;
 }
 

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -112,20 +112,24 @@ export function formatFriendCode(friendCode: number): string {
 
 async function setNickname(member: GuildMember, friendCode: number): Promise<void> {
 	// check for redundancy
-	const fcRegex = /\d{3}-\d{3}-\d{3}/;
+	const formatCode = formatFriendCode(friendCode);
 	const baseName = member.nickname || member.user.username;
-	if (fcRegex.test(baseName)) {
+	if (baseName.includes(formatCode)) {
 		return;
 	}
-	const formatCode = formatFriendCode(friendCode);
+
+	const fcRegex = /\d{3}-\d{3}-\d{3}/;
+	let newName = baseName.replace(fcRegex, formatCode);
+	if (newName === baseName) {
+		newName = `${baseName} ${formatCode}`;
+	}
+
 	const NAME_LENGTH_CAP = 32;
-	// add 1 for space
-	const totalLength = baseName.length + formatCode.length + 1;
-	if (totalLength > NAME_LENGTH_CAP) {
+	if (newName.length > NAME_LENGTH_CAP) {
 		// can we notify the user expecting otherwise any way?
 		return;
 	}
-	await member.setNickname(`${baseName} ${formatCode}`);
+	await member.setNickname(newName, `Friend code added by Emcee`);
 }
 
 async function registerParticipant(

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -118,6 +118,13 @@ async function setNickname(member: GuildMember, friendCode: number): Promise<voi
 		return;
 	}
 	const formatCode = formatFriendCode(friendCode);
+	const NAME_LENGTH_CAP = 32;
+	// add 1 for space
+	const totalLength = baseName.length + formatCode.length + 1;
+	if (totalLength > NAME_LENGTH_CAP) {
+		// can we notify the user expecting otherwise any way?
+		return;
+	}
 	await member.setNickname(`${baseName} ${formatCode}`);
 }
 


### PR DESCRIPTION
## Description

Pad display when code starts with 0 to match expected Master Duel format
Check expected name length against expected discord caps and don't try to change if it will fail for that reason

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
