### PR TITLE
Defer replies for /drop, /start, /finish

### DIFF
--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -105,9 +105,9 @@ export async function dropPlayer(
 	}
 
 	const playerMessage = `You have been dropped from ${tournament.name}.`;
-
+	const method = interaction?.deferred ? "editReply" : "reply";
 	if (interaction?.commandName === "drop") {
-		await interaction.reply(playerMessage);
+		await interaction[method](playerMessage);
 	} else {
 		await member.send(playerMessage);
 	}
@@ -115,7 +115,7 @@ export async function dropPlayer(
 	const hostMessage = `${userMention(member.id)} has been dropped from ${tournament.name}.`;
 
 	if (interaction && interaction.commandName !== "drop") {
-		await interaction.reply(hostMessage);
+		await interaction[method](hostMessage);
 	} else if (tournament.privateChannel) {
 		await send(member.client, tournament.privateChannel, hostMessage);
 	}

--- a/src/slash/drop.ts
+++ b/src/slash/drop.ts
@@ -31,6 +31,7 @@ export class DropCommand extends AutocompletableCommand {
 	}
 
 	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
+		await interaction.deferReply();
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName },

--- a/src/slash/finish.ts
+++ b/src/slash/finish.ts
@@ -33,6 +33,7 @@ export class FinishCommand extends AutocompletableCommand {
 	}
 
 	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
+		await interaction.deferReply();
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({ where: { name: tournamentName } });
 
@@ -55,6 +56,6 @@ export class FinishCommand extends AutocompletableCommand {
 
 		await role?.delete();
 
-		await interaction.reply(`${tournament.name} successfully concluded`);
+		await interaction.editReply(`${tournament.name} successfully concluded`);
 	}
 }

--- a/src/slash/start.ts
+++ b/src/slash/start.ts
@@ -32,6 +32,7 @@ export class StartCommand extends AutocompletableCommand {
 	}
 
 	protected override async execute(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
+		await interaction.deferReply();
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { name: tournamentName },
@@ -46,7 +47,7 @@ export class StartCommand extends AutocompletableCommand {
 		const playersToDrop = tournament.participants.filter(p => !p.deck?.approved);
 
 		if (playersToDrop.length === tournament.participants.length) {
-			await interaction.reply(`No players have an approved deck, so you cannot start the tournament.`);
+			await interaction.editReply(`No players have an approved deck, so you cannot start the tournament.`);
 			return;
 		}
 
@@ -76,6 +77,6 @@ export class StartCommand extends AutocompletableCommand {
 		tournament.status = TournamentStatus.IPR;
 		await tournament.save();
 
-		await interaction.reply(`${tournament.name} prepared for commencement!`);
+		await interaction.editReply(`${tournament.name} prepared for commencement!`);
 	}
 }


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

These commands have been empirically found to take more than three seconds.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
