### PR TITLE
authenticateHost: use interaction.deferred over an extra argument

### DIFF
--- a/src/slash/csv.ts
+++ b/src/slash/csv.ts
@@ -47,7 +47,7 @@ export class CsvCommand extends AutocompletableCommand {
 		const tournamentName = interaction.options.getString("tournament", true);
 		const tournament = await ManualTournament.findOneOrFail({ where: { name: tournamentName } });
 
-		if (!(await authenticateHost(tournament, interaction, true))) {
+		if (!(await authenticateHost(tournament, interaction))) {
 			// rejection messages handled in helper
 			return;
 		}

--- a/src/slash/database.ts
+++ b/src/slash/database.ts
@@ -36,17 +36,19 @@ export async function autocompleteTournament(interaction: AutocompleteInteractio
 
 export async function authenticateHost(
 	tournament: ManualTournament,
-	interaction: ChatInputCommandInteraction<"cached"> | ContextMenuCommandInteraction<"cached">,
-	isDeferred = false
+	interaction: ChatInputCommandInteraction<"cached"> | ContextMenuCommandInteraction<"cached">
 ): Promise<boolean> {
-	const func = isDeferred ? "editReply" : "reply";
+	const method = interaction.deferred ? "editReply" : "reply";
 	if (tournament.owningDiscordServer !== interaction.guildId) {
 		// ephemeral response preferred but deferred commands have to stay consistent and should be public in success
-		await interaction[func]({ content: `That tournament isn't in this server.`, ephemeral: !isDeferred });
+		await interaction[method]({
+			content: `That tournament isn't in this server.`,
+			ephemeral: !interaction.deferred
+		});
 		return false;
 	}
 	if (!tournament.hosts.includes(interaction.user.id)) {
-		await interaction[func]({ content: `You cannot use this.`, ephemeral: !isDeferred });
+		await interaction[method]({ content: `You cannot use this.`, ephemeral: !interaction.deferred });
 		return false;
 	}
 	return true;


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

Extra argument isn't necessary. Actually, `ephemeral: true` might be able to always be passed, since it's not considered by editReply, to test

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
