### PR TITLE
Request in-game name on manual tournament registration and nickname accordingly

### DIFF
--- a/src/database/orm/ManualParticipant.ts
+++ b/src/database/orm/ManualParticipant.ts
@@ -25,6 +25,10 @@ export class ManualParticipant<HasDeck extends boolean = boolean> extends BaseEn
 	@PrimaryColumn({ length: 20 })
 	discordId!: string;
 
+	/// Master Duel in-game name, if in use
+	@Column({ length: 12, nullable: true })
+	ign?: string;
+
 	/// Master Duel friend code, if in use
 	@Column({ type: "integer", nullable: true })
 	friendCode?: number;

--- a/src/events/interaction.ts
+++ b/src/events/interaction.ts
@@ -18,7 +18,7 @@ import { ForceDropContextCommand, ForceDropSlashCommand } from "../slash/forcedr
 import { HostCommand } from "../slash/host";
 import { InfoCommand } from "../slash/info";
 import { ListCommand } from "../slash/list";
-import { FriendCodeModalHandler, OpenCommand, RegisterButtonHandler } from "../slash/open";
+import { OpenCommand, RegisterButtonHandler, RegisterModalHandler } from "../slash/open";
 import { QueueCommand } from "../slash/queue";
 import { StartCommand } from "../slash/start";
 import { TimerCommand } from "../slash/timer";
@@ -55,7 +55,7 @@ export function makeHandler({ organiserRole, timeWizard }: CommandSupport) {
 		new QuickAcceptButtonHandler(),
 		new RejectButtonHandler()
 	];
-	const messageModalArray = [new FriendCodeModalHandler(), new AcceptLabelModal(), new RejectReasonModal()];
+	const messageModalArray = [new RegisterModalHandler(), new AcceptLabelModal(), new RejectReasonModal()];
 	const contextArray = [new ForceDropContextCommand()];
 
 	const commands = new Map<string, SlashCommand>();

--- a/src/slash/deck.ts
+++ b/src/slash/deck.ts
@@ -91,6 +91,9 @@ function rejectButton(tournamentId: number, playerId: string, messageId: string)
 export function generateDeckSubmissionMessage(deck: ManualDeckSubmission, user: User) {
 	// user should match deck.discordId, used for convenience
 	let content = `__**${user} (${escapeMarkdown(user.tag)})'s deck**__:`;
+	if (deck.participant.ign) {
+		content += `\n**IGN**: ${deck.participant.ign}`;
+	}
 	if (deck.participant.friendCode) {
 		content += `\n${formatFriendCode(deck.participant.friendCode)}`;
 	}

--- a/src/slash/open.ts
+++ b/src/slash/open.ts
@@ -253,7 +253,7 @@ export class RegisterModalHandler implements MessageModalSubmitHandler {
 		const tournament = await ManualTournament.findOneOrFail({
 			where: { owningDiscordServer: interaction.guildId, registerMessage: interaction.message.id }
 		});
-
+		const ign = interaction.fields.getTextInputValue("ign");
 		const friendCodeString = interaction.fields.getTextInputValue("friendCode");
 		const friendCode = parseFriendCode(friendCodeString);
 		if (!friendCode && tournament.requireFriendCode) {
@@ -263,6 +263,6 @@ export class RegisterModalHandler implements MessageModalSubmitHandler {
 			});
 			return;
 		}
-		await registerParticipant(interaction, tournament, friendCode, interaction.fields.getTextInputValue("ign"));
+		await registerParticipant(interaction, tournament, friendCode, ign);
 	}
 }


### PR DESCRIPTION
<!--
  Hello, thanks for submitting a pull request! Please provide enough information so we can review it.
-->

## Description

- the registration prompt asks (optional) for IGN if different than Discord name
- this is reported in the deck submission
- nickname is set to `${IGN ?? username} ${friendcode}`
- if nickname too long, set it to `${truncated}…${friendcode}`

New ManualParticipant column: ign
```sql
ALTER TABLE "manual_participant" ADD "ign" character varying(12);
```

In practice, truncation shouldn't happen with correct usage, as a Master Duel IGN is between 3 and 12 characters, which is guaranteed to fit in a nickname alongside the friend code. Truncation will only happen if the user does not specify an IGN and their Discord username is long. This is still a valid usage if their Discord username is sufficiently similar to their IGN.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
