### PR TITLE
/csv: Use Discord username when IGN not specified

### DIFF
--- a/src/slash/csv.ts
+++ b/src/slash/csv.ts
@@ -3,7 +3,6 @@ import { RESTPostAPIApplicationCommandsJSONBody } from "discord-api-types/v10";
 import { AutocompleteInteraction, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { ManualTournament } from "../database/orm";
 import { AutocompletableCommand } from "../SlashCommand";
-import { username } from "../util/discord";
 import { getLogger, Logger } from "../util/logger";
 import { authenticateHost, autocompleteTournament, tournamentOption } from "./database";
 import { formatFriendCode } from "./open";
@@ -71,11 +70,13 @@ export class CsvCommand extends AutocompletableCommand {
 			const players = tournament.decks
 				.filter(d => d.approved)
 				.map(async deck => {
-					const tag = (await username(interaction.client, deck.discordId)) || deck.discordId;
+					const user = await interaction.client.users.fetch(deck.discordId);
+					const tag = user ? user.tag : deck.discordId;
+					const name = user ? user.username : "No IGN";
 					return {
 						Player: tag,
 						Theme: deck.label || "No theme",
-						"In-Game Name": deck.participant.ign || tag,
+						"In-Game Name": deck.participant.ign || name,
 						"Friend Code": deck.participant.friendCode
 							? formatFriendCode(deck.participant.friendCode)
 							: "No friend code"

--- a/src/slash/csv.ts
+++ b/src/slash/csv.ts
@@ -75,7 +75,7 @@ export class CsvCommand extends AutocompletableCommand {
 					return {
 						Player: tag,
 						Theme: deck.label || "No theme",
-						"In-Game Name": deck.participant.ign || "No IGN",
+						"In-Game Name": deck.participant.ign || tag,
 						"Friend Code": deck.participant.friendCode
 							? formatFriendCode(deck.participant.friendCode)
 							: "No friend code"


### PR DESCRIPTION
## Description

Per client request, this better suits the needs of tournament management.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/.github/CONTRIBUTING.md).
- [ ] I have updated any relevant [user guides](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/guides).
- [ ] I have updated any relevant [documentation](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/docs).
- [ ] I have updated the [changelog](https://github.com/DawnbrandBots/emcee-tournament-bot/blob/master/changelog.md), or this change is not user-facing.
